### PR TITLE
공연 상세 - 전체보기 구현

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/Main.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/Main.kt
@@ -12,8 +12,10 @@ import androidx.navigation.NavController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import androidx.navigation.navigation
 import com.nexters.boolti.presentation.screen.home.HomeScreen
 import com.nexters.boolti.presentation.screen.login.LoginScreen
 import com.nexters.boolti.presentation.screen.payment.AccountTransferScreen
@@ -73,38 +75,42 @@ fun MainNavigation(modifier: Modifier, viewModel: MainViewModel = hiltViewModel(
                 navController.popBackStack()
             }
         }
-        composable(
-            route = "show/{showId}",
-            arguments = listOf(navArgument("showId") { type = NavType.StringType }),
-        ) { entry ->
-            val showId = requireNotNull(entry.arguments?.getString("showId"))
-            val showViewModel: ShowDetailViewModel = entry.sharedViewModel(navController = navController)
 
-            ShowDetailScreen(
-                onBack = { navController.popBackStack() },
-                onClickHome = {
-                    navController.popBackStack(navController.graph.startDestinationId, true)
-                    navController.navigate("home")
-                },
-                onClickContent = {
-                    navController.navigate("show/detail/${showId}")
-                },
-                modifier = modifier,
-                onTicketSelected = { navController.navigate("ticketing/$it") },
-                viewModel = showViewModel,
-            )
-        }
-        composable(
-            route = "show/detail/{showId}",
+        navigation(
+            route = "show/{showId}",
+            startDestination = "detail",
             arguments = listOf(navArgument("showId") { type = NavType.StringType }),
-        ) { entry ->
-            val showViewModel: ShowDetailViewModel = entry.sharedViewModel(navController = navController)
-            
-            ShowDetailContentScreen(
-                modifier = modifier,
-                viewModel = showViewModel,
-                onBackPressed = { navController.popBackStack() }
-            )
+        ) {
+            composable(
+                route = "detail",
+            ) { entry ->
+                val showViewModel: ShowDetailViewModel = entry.sharedViewModel(navController = navController)
+
+                ShowDetailScreen(
+                    onBack = { navController.popBackStack() },
+                    onClickHome = {
+                        navController.popBackStack(navController.graph.startDestinationId, true)
+                        navController.navigate("home")
+                    },
+                    onClickContent = {
+                        navController.navigate("content")
+                    },
+                    modifier = modifier,
+                    onTicketSelected = { navController.navigate("ticketing/$it") },
+                    viewModel = showViewModel,
+                )
+            }
+            composable(
+                route = "content",
+            ) { entry ->
+                val showViewModel: ShowDetailViewModel = entry.sharedViewModel(navController = navController)
+
+                ShowDetailContentScreen(
+                    modifier = modifier,
+                    viewModel = showViewModel,
+                    onBackPressed = { navController.popBackStack() }
+                )
+            }
         }
         composable(
             route = "ticket/{ticketId}",


### PR DESCRIPTION
## Issue
- close #69 

## 작업 내용
- 전체 보기 구현

<img src="https://github.com/Nexters/Boolti/assets/35232655/be5b5da2-773f-4df4-8151-6353016e26cd" width="300" />

## 코멘트
- 실수로 develop에 바로 푸시하는 짓을 저질러 버렸습니다...
![image](https://github.com/Nexters/Boolti/assets/35232655/56cd600c-b084-4ad4-9d9d-a813c94207b2)
- 이후로 머지 커밋이 쌓여서 롤백은 어려울 거 같고, PR 대상 브랜치만 롤백 버전으로 만들어서 이미 develop에 푸시된 코드까지 이 PR에서 한 번에 볼 수 있게 만들어 놨고, approve 되면 수동으로 develop에 머지할 거 같아.
