### PR TITLE
 signingConfig 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 .externalNativeBuild
 .cxx
 local.properties
+keystore.properties
+/keystore.properties
 ### Android template
 # Gradle files
 .gradle/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+import java.io.FileInputStream
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
@@ -10,9 +12,22 @@ plugins {
     id("kotlin-parcelize")
 }
 
+val keystorePropertiesFile = rootProject.file("keystore.properties")
+val keystoreProperties = Properties()
+keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+
 android {
     namespace = libs.versions.packageName.get()
     compileSdk = libs.versions.compileSdk.get().toInt()
+
+    signingConfigs {
+        create("release") {
+            storeFile = file(keystoreProperties["storeFile"] as String)
+            storePassword = keystoreProperties["storePassword"] as String
+            keyAlias = keystoreProperties["keyAlias"] as String
+            keyPassword = keystoreProperties["keyPassword"] as String
+        }
+    }
 
     defaultConfig {
         applicationId = "com.nexters.boolti"
@@ -33,6 +48,7 @@ android {
         release {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            signingConfig = signingConfigs.getByName("release")
         }
         debug {
             isDebuggable = true


### PR DESCRIPTION
## Issue
- close #77 

## 작업 내용

release 빌드를 위한 signingConfig 설정.

## Release 빌드하는 법

1. 전달해준 keystore 파일을 적당한 위치에 저장한다
2. 루트 프로젝트 밑에 keystore.properties 파일을 생성한다
<img width="365" alt="image" src="https://github.com/Nexters/Boolti/assets/44221447/8fab6699-2079-4c8b-b416-26231af33690">

3. keystore.properties 파일에 전달해준 [storeFile, storePassword, keyAlias, keyPassword] 값을 넣는다.
4. release 로 Build Variant 변경해서 빌드되는지 확인
