### PR TITLE
Boolti-127 fix: 강제 업데이트 필요 시 앱 프리징 이슈 해결

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/splash/SplashActivity.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/splash/SplashActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -39,10 +40,8 @@ class SplashActivity : ComponentActivity() {
     private val viewModel: SplashViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val splashScreen = installSplashScreen()
+        installSplashScreen()
         super.onCreate(savedInstanceState)
-
-        splashScreen.setKeepOnScreenCondition { true }
 
         setContent {
             BooltiTheme {
@@ -75,7 +74,7 @@ fun SplashScreen(
     onSuccessVersionCheck: () -> Unit,
     onClickUpdate: () -> Unit,
 ) {
-    Box(modifier = modifier.fillMaxSize()) {
+    Box(modifier = modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
         when (shouldUpdate) {
             true -> UpdateDialog(onClickUpdate = onClickUpdate)
             false -> onSuccessVersionCheck()


### PR DESCRIPTION
## Issue
- close #127 

## 작업 내용

- `splashScreen.setKeepOnScreenCondition { true }` 코드 제거
- 스플래시 끝나고 메인으로 넘어갈 때 흰 화면이 번쩍 보이므로 백그라운드 설정해 줌
