### PR TITLE
Feature/boolti 140 입력 창 요구사항 반영

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/BTTextField.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/BTTextField.kt
@@ -1,18 +1,22 @@
 package com.nexters.boolti.presentation.component
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -20,6 +24,7 @@ import com.nexters.boolti.presentation.theme.BooltiTheme
 import com.nexters.boolti.presentation.theme.Error
 import com.nexters.boolti.presentation.theme.Grey70
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BTTextField(
     text: String,
@@ -55,26 +60,51 @@ fun BTTextField(
     ),
 ) {
     val interactionSource = remember { MutableInteractionSource() }
-    OutlinedTextField(
+    val shape = RoundedCornerShape(4.dp)
+
+    BasicTextField(
         value = text,
         onValueChange = onValueChanged,
-        modifier = modifier,
+        modifier = modifier.defaultMinSize(minHeight = 48.dp, minWidth = OutlinedTextFieldDefaults.MinWidth),
         enabled = enabled,
         readOnly = readOnly,
         textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
-        placeholder = {
-            Text(placeholder, style = MaterialTheme.typography.bodyLarge.copy(color = Grey70))
-        },
+        cursorBrush = SolidColor(if (isError) colors.errorCursorColor else colors.cursorColor),
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
-        interactionSource = interactionSource,
         singleLine = singleLine,
         maxLines = maxLines,
         minLines = minLines,
-        isError = isError,
         visualTransformation = visualTransformation,
-        shape = RoundedCornerShape(4.dp),
-        colors = colors,
+        interactionSource = interactionSource,
+        decorationBox = { innerTextField ->
+            OutlinedTextFieldDefaults.DecorationBox(
+                value = text,
+                visualTransformation = visualTransformation,
+                innerTextField = innerTextField,
+                placeholder = {
+                    Text(
+                        text = placeholder,
+                        style = MaterialTheme.typography.bodyLarge.copy(color = Grey70),
+                    )
+                },
+                singleLine = singleLine,
+                enabled = enabled,
+                isError = isError,
+                interactionSource = interactionSource,
+                colors = colors,
+                contentPadding = PaddingValues(horizontal = 12.dp),
+                container = {
+                    OutlinedTextFieldDefaults.ContainerBox(
+                        shape = shape,
+                        enabled = enabled,
+                        isError = isError,
+                        interactionSource = interactionSource,
+                        colors = colors,
+                    )
+                },
+            )
+        },
     )
 }
 

--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/BTTextField.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/BTTextField.kt
@@ -93,7 +93,7 @@ fun BTTextField(
                 isError = isError,
                 interactionSource = interactionSource,
                 colors = colors,
-                contentPadding = PaddingValues(horizontal = 12.dp),
+                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 12.dp),
                 container = {
                     OutlinedTextFieldDefaults.ContainerBox(
                         shape = shape,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/refund/RefundScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/refund/RefundScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -39,8 +38,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -233,28 +230,16 @@ fun ReasonPage(
             text = stringResource(id = R.string.refund_reason_label),
             style = point4,
         )
-        TextField(modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = marginHorizontal)
-            .height(160.dp)
-            .padding(top = 20.dp)
-            .clip(shape = RoundedCornerShape(4.dp)),
-            value = reason,
-            onValueChange = onReasonChanged,
-            textStyle = MaterialTheme.typography.bodyLarge.copy(color = Grey10),
-            colors = TextFieldDefaults.colors(
-                focusedContainerColor = Grey85,
-                unfocusedContainerColor = Grey85,
-                focusedIndicatorColor = Color.Transparent,
-                unfocusedIndicatorColor = Color.Transparent,
-            ),
-            shape = RoundedCornerShape(4.dp),
-            placeholder = {
-                Text(
-                    text = stringResource(id = R.string.refund_reason_hint),
-                    style = MaterialTheme.typography.bodyLarge.copy(color = Grey70),
-                )
-            })
+        BTTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = marginHorizontal)
+                .height(160.dp)
+                .padding(top = 20.dp),
+            text = reason,
+            onValueChanged = onReasonChanged,
+            placeholder = stringResource(id = R.string.refund_reason_hint),
+        )
 
         Spacer(modifier = Modifier.weight(1.0f))
         MainButton(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/report/ReportScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/report/ReportScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nexters.boolti.presentation.R
+import com.nexters.boolti.presentation.component.BTTextField
 import com.nexters.boolti.presentation.component.BtAppBar
 import com.nexters.boolti.presentation.component.MainButton
 import com.nexters.boolti.presentation.theme.Grey10
@@ -77,29 +78,16 @@ fun ReportScreen(
                 text = stringResource(id = R.string.report_description),
                 style = MaterialTheme.typography.bodyLarge.copy(color = Grey30),
             )
-            TextField(modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = marginHorizontal)
-                .height(160.dp)
-                .padding(top = 20.dp)
-                .clip(shape = RoundedCornerShape(4.dp)),
-                value = uiState.reason,
-                onValueChange = viewModel::updateReason,
-                textStyle = MaterialTheme.typography.bodyLarge.copy(color = Grey10),
-                colors = TextFieldDefaults.colors(
-                    focusedContainerColor = Grey85,
-                    unfocusedContainerColor = Grey85,
-                    focusedIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent,
-                ),
-                shape = RoundedCornerShape(4.dp),
-                placeholder = {
-                    Text(
-                        text = stringResource(id = R.string.report_reason_hint),
-                        style = MaterialTheme.typography.bodyLarge.copy(color = Grey70),
-                    )
-                })
-
+            BTTextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = marginHorizontal)
+                    .height(160.dp)
+                    .padding(top = 20.dp),
+                text = uiState.reason,
+                placeholder = stringResource(id = R.string.report_reason_hint),
+                onValueChanged = viewModel::updateReason,
+            )
             Spacer(modifier = Modifier.weight(1.0f))
             MainButton(
                 modifier = Modifier

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticket/detail/ManagerCodeDialog.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticket/detail/ManagerCodeDialog.kt
@@ -8,8 +8,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -31,13 +35,20 @@ fun ManagerCodeDialog(
     onDismiss: () -> Unit,
     onClickConfirm: (managerCode: String) -> Unit,
 ) {
+    val code = managerCode.filter { it.isDigit() }
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(focusRequester) {
+        focusRequester.requestFocus()
+    }
+
     BTDialog(
+        modifier = Modifier.focusRequester(focusRequester),
         onDismiss = {
             onManagerCodeChanged("")
             onDismiss()
         },
-        onClickPositiveButton = { onClickConfirm(managerCode) },
-        positiveButtonEnabled = managerCode.isNotEmpty(),
+        onClickPositiveButton = { onClickConfirm(code) },
+        positiveButtonEnabled = code.isNotEmpty(),
     ) {
         Text(
             text = stringResource(R.string.enter_code_dialog_title),
@@ -56,7 +67,7 @@ fun ManagerCodeDialog(
             color = Grey50,
         )
         BTTextField(
-            text = managerCode,
+            text = code,
             placeholder = stringResource(R.string.enter_code_dialog_placeholder),
             onValueChanged = {
                 onManagerCodeChanged(it)
@@ -65,13 +76,12 @@ fun ManagerCodeDialog(
                 .fillMaxWidth()
                 .padding(top = 24.dp),
             keyboardOptions = KeyboardOptions(
-                capitalization = KeyboardCapitalization.Words,
                 autoCorrect = false,
-                keyboardType = KeyboardType.Text,
+                keyboardType = KeyboardType.Decimal,
                 imeAction = ImeAction.Done,
             ),
             keyboardActions = KeyboardActions(
-                onDone = { onClickConfirm(managerCode) }
+                onDone = { onClickConfirm(code) }
             ),
             singleLine = true,
             colors = OutlinedTextFieldDefaults.colors(
@@ -95,7 +105,9 @@ fun ManagerCodeDialog(
                 text = message,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.error,
-                modifier = Modifier.padding(top = 8.dp).align(Alignment.Start),
+                modifier = Modifier
+                    .padding(top = 8.dp)
+                    .align(Alignment.Start),
             )
         }
     }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingScreen.kt
@@ -363,6 +363,7 @@ private fun InviteCodeSection(
                 text = inviteCode.uppercase(),
                 singleLine = true,
                 enabled = inviteCodeStatus !is InviteCodeStatus.Valid,
+                isError = inviteCodeStatus is InviteCodeStatus.Invalid,
                 placeholder = stringResource(R.string.ticketing_invite_code_placeholder),
                 keyboardOptions = KeyboardOptions.Default.copy(
                     keyboardType = KeyboardType.Password,
@@ -374,9 +375,10 @@ private fun InviteCodeSection(
                 },
             )
             Button(
+                modifier = Modifier.height(48.dp),
                 onClick = onClickCheckInviteCode,
                 enabled = inviteCodeStatus !is InviteCodeStatus.Valid && inviteCode.isNotBlank(),
-                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 13.dp),
+                contentPadding = PaddingValues(horizontal = 20.dp),
                 shape = RoundedCornerShape(4.dp),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = Grey20,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingScreen.kt
@@ -53,10 +53,10 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
@@ -360,16 +360,17 @@ private fun InviteCodeSection(
                 modifier = Modifier
                     .weight(1F)
                     .padding(end = 6.dp),
-                text = inviteCode,
+                text = inviteCode.uppercase(),
                 singleLine = true,
                 enabled = inviteCodeStatus !is InviteCodeStatus.Valid,
                 placeholder = stringResource(R.string.ticketing_invite_code_placeholder),
                 keyboardOptions = KeyboardOptions.Default.copy(
                     keyboardType = KeyboardType.Password,
                     imeAction = ImeAction.Done,
+                    capitalization = KeyboardCapitalization.Characters,
                 ),
                 onValueChanged = {
-                    onInviteCodeChanged(it)
+                    onInviteCodeChanged(it.uppercase())
                 },
             )
             Button(


### PR DESCRIPTION
## Issue
- close #140 

## 작업 내용

- 입장 코드 숫자만 받도록 변경
- 입장 코드 다이얼로그 띄울 때 포커즈 받도록 수정
- 초청 코드 대문자만 입력되도록 변경
- 초청 코드 오류 시 에러 보더 표시
- 입력창 높이 48dp 로 변경

<img width="300" alt="image" src="https://github.com/Nexters/Boolti/assets/44221447/0c7e6d37-6e60-495b-b076-88f7a4875b35">
