### PR TITLE
Fix/159 홈 스크롤 모션 수정 이제 완벽해~~

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/show/ShowScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/show/ShowScreen.kt
@@ -81,7 +81,6 @@ fun ShowScreen(
     val changeableAppBarHeightPx =
         with(LocalDensity.current) { (appbarHeight - searchBarHeight).roundToPx().toFloat() }
     var appbarOffsetHeightPx by rememberSaveable { mutableFloatStateOf(0f) }
-    var changeableAppBarHeight by remember { mutableFloatStateOf(0f) }
     val nestedScrollConnection = remember {
         object : NestedScrollConnection {
             override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
@@ -138,18 +137,12 @@ fun ShowScreen(
                 nickname = nickname.ifBlank { stringResource(id = R.string.nickname_default) },
                 text = uiState.keyword,
                 onKeywordChanged = viewModel::updateKeyword,
-                onChangeableSizeChanged = { size ->
-                    changeableAppBarHeight = size.height.toFloat()
-                },
                 search = viewModel::search,
             )
         }
     }
 }
 
-/**
- * @param onChangeableSizeChanged 변할 수 있는 최대 사이즈를 전달 app bar height - search bar
- */
 @Composable
 fun ShowAppBar(
     text: String,
@@ -157,20 +150,13 @@ fun ShowAppBar(
     navigateToReservations: () -> Unit,
     nickname: String,
     onKeywordChanged: (keyword: String) -> Unit,
-    onChangeableSizeChanged: (size: IntSize) -> Unit,
     search: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var appBarHeight by remember { mutableFloatStateOf(0f) }
-    val searchBarHeight = with(LocalDensity.current) { 80.dp.toPx() }
     Column(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = marginHorizontal)
-            .onSizeChanged(onSizeChanged = { size ->
-                appBarHeight = size.height.toFloat()
-                onChangeableSizeChanged(IntSize(0, size.height - searchBarHeight.toInt()))
-            })
     ) {
         Spacer(modifier = Modifier.height(20.dp))
         if (hasPendingTicket) Banner(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/show/ShowScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/show/ShowScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -59,6 +60,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nexters.boolti.presentation.R
 import com.nexters.boolti.presentation.component.ShowFeed
+import com.nexters.boolti.presentation.extension.toPx
 import com.nexters.boolti.presentation.theme.Grey15
 import com.nexters.boolti.presentation.theme.Grey60
 import com.nexters.boolti.presentation.theme.Grey70
@@ -76,10 +78,11 @@ fun ShowScreen(
     val user by viewModel.user.collectAsStateWithLifecycle()
     val nickname = user?.nickname ?: ""
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val lazyGridState = rememberLazyGridState()
     val appbarHeight = if (uiState.hasPendingTicket) 196.dp + 52.dp else 196.dp
     val searchBarHeight = 80.dp
-    val changeableAppBarHeightPx =
-        with(LocalDensity.current) { (appbarHeight - searchBarHeight).roundToPx().toFloat() }
+    val changeableAppBarHeightPx = (appbarHeight - searchBarHeight).toPx()
     var appbarOffsetHeightPx by rememberSaveable { mutableFloatStateOf(0f) }
     val nestedScrollConnection = remember {
         object : NestedScrollConnection {
@@ -87,6 +90,15 @@ fun ShowScreen(
                 appbarOffsetHeightPx += available.y
 
                 return Offset.Zero
+            }
+
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource
+            ): Offset {
+                appbarOffsetHeightPx -= available.y
+                return super.onPostScroll(consumed, available, source)
             }
         }
     }
@@ -110,6 +122,7 @@ fun ShowScreen(
             LazyVerticalGrid(
                 modifier = Modifier
                     .padding(horizontal = marginHorizontal),
+                state = lazyGridState,
                 columns = GridCells.Adaptive(minSize = 150.dp),
                 horizontalArrangement = Arrangement.spacedBy(15.dp),
                 verticalArrangement = Arrangement.spacedBy(28.dp),
@@ -129,7 +142,7 @@ fun ShowScreen(
                 modifier = Modifier.offset {
                     IntOffset(
                         x = 0,
-                        y = appbarOffsetHeightPx.coerceIn(-changeableAppBarHeightPx, 0f).toInt()
+                        y = appbarOffsetHeightPx.coerceAtLeast(-changeableAppBarHeightPx).toInt(),
                     )
                 },
                 navigateToReservations = navigateToReservations,


### PR DESCRIPTION
## Issue
- close #159 

## 작업 내용
- 필요 없는 로직 제거
- 스크롤 잔량만큼 롤백

https://github.com/Nexters/Boolti/assets/35232655/93805b16-1a64-42a5-a277-4e08190c6de8

## 코멘트 TL; DR
- preScroll은 자식놈의 LazyGrid의 스크롤을 감지하여 먼저 사용하는 메서드이다. return 값은 소비한 스크롤을 의미한다. 현재 로직에서는 자식 스크롤을 훔쳐보긴 하지만 뺏어가진 않는다.
- 스크롤 도중에는 문제가 없다. 모든 스크롤을 소비한다.
- 스크롤이 끝에 도달했을 때도 문제가 없다. 스크롤 해도 offset이 0으로 감지 된다.
- 스크롤 하다가 끝에 도달한 경우 감지된 offset의 일부만 쓰고 잔량이 남는다. 문제는 이 잔량은 preScroll에서도 처리하면 안 되는데, 이 잔량을 처리하여 문제가 발생한다.
- 그래서 이 잔량만큼 되돌려주었더니 모든 문제가 해결되었다.