### PR TITLE
66 / zoomable 추가

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ google-services = "4.4.0"
 firebase-crashlytics = "2.9.9"
 firebase-config = "21.6.0"
 kotest = "5.8.0"
+zoomable = "1.6.0"
 zxing = "4.3.0"
 kakao = "2.19.0"
 timber = "5.0.1"
@@ -101,6 +102,7 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-analytics-ktx = { module = "com.google.firebase:firebase-analytics-ktx", version.require = "false" }
 firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics-ktx", version.require = "false" }
 firebase-config-ktx = { module = "com.google.firebase:firebase-config-ktx", version.ref = "firebase-config" }
+zoomable = { module = "net.engawapg.lib:zoomable", version.ref = "zoomable" }
 zxing-android-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxing" }
 kakao-login = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakao" }
 retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "serializationConverter" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation(libs.hilt.android)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.material3.android)
+    implementation(libs.zoomable)
     kapt(libs.hilt.compiler)
 
     implementation(libs.lottie)

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/show/ShowImagesScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/show/ShowImagesScreen.kt
@@ -27,6 +27,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.nexters.boolti.presentation.R
 import com.nexters.boolti.presentation.component.BtAppBar
+import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.zoomable
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -67,7 +69,8 @@ fun ShowImagesScreen(
             ) {
                 AsyncImage(
                     modifier = Modifier
-                        .fillMaxWidth(),
+                        .fillMaxWidth()
+                        .zoomable(rememberZoomState()),
                     model = uiState.showDetail.images[it].originImage,
                     contentDescription = null,
                     contentScale = ContentScale.FillWidth,


### PR DESCRIPTION
## Issue
- close #66 

## 작업 내용
- 이미지 zoom 추가

https://github.com/Nexters/Boolti/assets/35232655/86552fb1-1e9b-4556-8cc2-c90144a4c1c0

## 코멘트
- 오픈소스 만들 생각에 신났었는데,,, 이미 다 있는 기능이었어...
- 내부적으로는 detectTransformGestures를 재정의하여 구현하고 있어.
- 기본 detectTransformGestures를 호출하면 events를 소비하게 되어 있는데, 특정 offset (bound)에서 pan 이벤트가 발생하면 이벤트를 소비하지 않도록 구현하여 만들지 않았을까 추측해봅니다.
