### PR TITLE
Boolti-172 style: 티켓 목록 포스터 scale type 변경

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticket/TicketContent.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticket/TicketContent.kt
@@ -138,7 +138,7 @@ fun TicketContent(
                     .padding(top = 20.dp, start = 20.dp, end = 20.dp)
                     .clip(RoundedCornerShape(8.dp)),
                 model = ticket.poster,
-                contentScale = ContentScale.FillWidth,
+                contentScale = ContentScale.Crop,
                 contentDescription = stringResource(R.string.description_poster),
             )
             DottedDivider(


### PR DESCRIPTION
## Issue
- close #172 

## 작업 내용

FillWidth 에서 Crop 으로 변경

이유는 일관된 포스터 영역을 보여주기 위함. 전체 포스터를 확인하기 위해서는 티켓 상세에서 포스터를 눌러서 zoomable 화면으로 이동시키면 좋을 듯 (논의는 됐지만 결정이 확실히 났는지 모르겠어서 일단 작업은 보류)

추가로 rounded corner 문제 해결

### 기존

<img width="300" alt="image" src="https://github.com/Nexters/Boolti/assets/44221447/d9b92d72-9922-4af7-90d2-abddc59b548b">

### 변경 후

<img width="300" alt="image" src="https://github.com/Nexters/Boolti/assets/44221447/53f4eea6-ccc0-4e86-ae65-d40716fe2075">

