### PR TITLE
Feature/176 snackbar 보일러 플레이트 코드 개선

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/Main.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/Main.kt
@@ -1,10 +1,17 @@
 package com.nexters.boolti.presentation.screen
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavBackStackEntry
@@ -15,6 +22,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.nexters.boolti.presentation.component.ToastSnackbarHost
 import com.nexters.boolti.presentation.extension.navigateToHome
 import com.nexters.boolti.presentation.screen.home.HomeScreen
 import com.nexters.boolti.presentation.screen.login.LoginScreen
@@ -33,13 +41,40 @@ import com.nexters.boolti.presentation.screen.signout.SignoutScreen
 import com.nexters.boolti.presentation.screen.ticket.detail.TicketDetailScreen
 import com.nexters.boolti.presentation.screen.ticketing.TicketingScreen
 import com.nexters.boolti.presentation.theme.BooltiTheme
+import com.nexters.boolti.presentation.util.SnackbarController
+
+val LocalSnackbarController = staticCompositionLocalOf {
+    SnackbarController(SnackbarHostState())
+}
 
 @Composable
 fun Main(onClickQrScan: (showId: String, showName: String) -> Unit) {
     val modifier = Modifier.fillMaxSize()
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+
     BooltiTheme {
         Surface(modifier) {
-            MainNavigation(modifier, onClickQrScan)
+            Scaffold(
+                snackbarHost = {
+                    ToastSnackbarHost(
+                        modifier = Modifier.padding(bottom = 80.dp),
+                        hostState = snackbarHostState,
+                    )
+                },
+            ) { innerPadding ->
+                CompositionLocalProvider(
+                    LocalSnackbarController provides SnackbarController(
+                        snackbarHostState,
+                        scope
+                    )
+                ) {
+                    MainNavigation(
+                        modifier = modifier.padding(innerPadding),
+                        onClickQrScan = onClickQrScan,
+                    )
+                }
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/refund/RefundScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/refund/RefundScreen.kt
@@ -74,6 +74,7 @@ import com.nexters.boolti.presentation.component.BTTextField
 import com.nexters.boolti.presentation.component.BtAppBar
 import com.nexters.boolti.presentation.component.MainButton
 import com.nexters.boolti.presentation.extension.filterToPhoneNumber
+import com.nexters.boolti.presentation.screen.LocalSnackbarController
 import com.nexters.boolti.presentation.theme.Error
 import com.nexters.boolti.presentation.theme.Grey10
 import com.nexters.boolti.presentation.theme.Grey15
@@ -98,17 +99,16 @@ fun RefundScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val events = viewModel.events
     val scope = rememberCoroutineScope()
-    val context = LocalContext.current
     val pagerState = rememberPagerState { 2 }
     var openDialog by remember { mutableStateOf(false) }
+    val snackbarController = LocalSnackbarController.current
 
     val refundMessage = stringResource(id = R.string.refund_completed)
     LaunchedEffect(Unit) {
         events.collect { event ->
             when (event) {
                 RefundEvent.SuccessfullyRefunded -> {
-                    // TODO 스낵바로 변경
-                    Toast.makeText(context, refundMessage, Toast.LENGTH_LONG).show()
+                    snackbarController.showMessage(refundMessage)
                     onBackPressed()
                 }
             }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservations/ReservationDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservations/ReservationDetailScreen.kt
@@ -58,6 +58,7 @@ import com.nexters.boolti.presentation.component.CopyButton
 import com.nexters.boolti.presentation.component.ToastSnackbarHost
 import com.nexters.boolti.presentation.constants.datetimeFormat
 import com.nexters.boolti.presentation.extension.toDescriptionAndColorPair
+import com.nexters.boolti.presentation.screen.LocalSnackbarController
 import com.nexters.boolti.presentation.theme.Grey10
 import com.nexters.boolti.presentation.theme.Grey15
 import com.nexters.boolti.presentation.theme.Grey20
@@ -78,8 +79,6 @@ fun ReservationDetailScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val refundPolicy by viewModel.refundPolicy.collectAsStateWithLifecycle()
-    val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
         viewModel.fetchReservation()
@@ -87,12 +86,6 @@ fun ReservationDetailScreen(
 
     Scaffold(
         modifier = modifier,
-        snackbarHost = {
-            ToastSnackbarHost(
-                modifier = Modifier.padding(bottom = 80.dp),
-                hostState = snackbarHostState,
-            )
-        },
         topBar = { ReservationDetailAppBar(onBackPressed = onBackPressed) }) { innerPadding ->
 
         val state = uiState
@@ -113,11 +106,7 @@ fun ReservationDetailScreen(
             )
             Header(reservation = state.reservation)
             if (!state.reservation.isInviteTicket) {
-                DepositInfo(
-                    reservation = state.reservation,
-                    showMessage = { message ->
-                        scope.launch { snackbarHostState.showSnackbar(message) }
-                    })
+                DepositInfo(reservation = state.reservation)
             }
             PaymentInfo(reservation = state.reservation)
             TicketInfo(reservation = state.reservation)
@@ -211,10 +200,11 @@ private fun Header(
 
 @Composable
 private fun DepositInfo(
-    reservation: ReservationDetail,
-    showMessage: (message: String) -> Unit,
     modifier: Modifier = Modifier,
+    reservation: ReservationDetail,
 ) {
+    val snackbarController = LocalSnackbarController.current
+
     Section(
         modifier = modifier,
         title = stringResource(id = R.string.reservation_account_info),
@@ -242,7 +232,7 @@ private fun DepositInfo(
                     onClick = {
                         clipboardManager.setText(AnnotatedString(reservation.accountNumber))
                         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
-                            showMessage(copiedMessage)
+                            snackbarController.showMessage(copiedMessage)
                         }
                     },
                 )

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/show/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/show/ShowDetailScreen.kt
@@ -61,6 +61,7 @@ import com.nexters.boolti.presentation.component.CopyButton
 import com.nexters.boolti.presentation.component.MainButton
 import com.nexters.boolti.presentation.component.ToastSnackbarHost
 import com.nexters.boolti.presentation.extension.requireActivity
+import com.nexters.boolti.presentation.screen.LocalSnackbarController
 import com.nexters.boolti.presentation.screen.ticketing.ChooseTicketBottomSheet
 import com.nexters.boolti.presentation.theme.Grey05
 import com.nexters.boolti.presentation.theme.Grey20
@@ -95,7 +96,6 @@ fun ShowDetailScreen(
     val isLoggedIn by viewModel.loggedIn.collectAsStateWithLifecycle()
 
     val scope = rememberCoroutineScope()
-    val snackbarHostState = remember { SnackbarHostState() }
     var showBottomSheet by remember { mutableStateOf(false) }
 
     val window = LocalContext.current.requireActivity().window
@@ -103,12 +103,6 @@ fun ShowDetailScreen(
 
     Scaffold(
         modifier = modifier,
-        snackbarHost = {
-            ToastSnackbarHost(
-                modifier = Modifier.padding(bottom = 80.dp),
-                hostState = snackbarHostState,
-            )
-        },
         topBar = {
             ShowDetailAppBar(
                 onBack = onBack,
@@ -137,7 +131,6 @@ fun ShowDetailScreen(
                     modifier = Modifier
                         .padding(horizontal = marginHorizontal)
                         .padding(bottom = 114.dp),
-                    snackbarHost = snackbarHostState,
                     showDetail = uiState.showDetail,
                     host = stringResource(
                         id = R.string.ticketing_host_format,
@@ -168,11 +161,6 @@ fun ShowDetailScreen(
                 ShowDetailCtaButton(
                     showState = uiState.showDetail.state,
                     purchased = uiState.showDetail.isReserved,
-                    showMessage = { message ->
-                        scope.launch {
-                            snackbarHostState.showSnackbar(message = message)
-                        }
-                    },
                     onClick = {
                         scope.launch {
                             if (isLoggedIn == true) {
@@ -315,13 +303,12 @@ private fun ShowDetailAppBar(
 
 @Composable
 private fun ContentScaffold(
-    snackbarHost: SnackbarHostState,
     showDetail: ShowDetail,
     host: String,
     onClickContent: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val scope = rememberCoroutineScope()
+    val snackbarController = LocalSnackbarController.current
 
     Column(
         modifier = modifier,
@@ -361,9 +348,7 @@ private fun ContentScaffold(
                         onClick = {
                             clipboardManager.setText(AnnotatedString(showDetail.streetAddress))
                             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
-                                scope.launch {
-                                    snackbarHost.showSnackbar(copiedMessage)
-                                }
+                                snackbarController.showMessage(copiedMessage)
                             }
                         }
                     )
@@ -498,7 +483,6 @@ private fun SectionContent(
 @Composable
 fun ShowDetailCtaButton(
     onClick: () -> Unit,
-    showMessage: (message: String) -> Unit,
     purchased: Boolean,
     showState: ShowState,
     modifier: Modifier = Modifier,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/util/SnackbarController.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/util/SnackbarController.kt
@@ -1,0 +1,19 @@
+package com.nexters.boolti.presentation.util
+
+import androidx.compose.material3.SnackbarHostState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+class SnackbarController(
+    private val snackbarHostState: SnackbarHostState,
+    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob()),
+) {
+    fun showMessage(
+        message: String,
+    ) {
+        coroutineScope.launch {
+            snackbarHostState.showSnackbar(message)
+        }
+    }
+}


### PR DESCRIPTION
이번엔 다소 실험적인(?) 코드를 가져와 봤어.

## Issue
- close #176 

## 작업 내용
- 기본 스낵바일 경우 쉽게 사용할 수 있도록 SnackbarController 구현

다음 문제점 개선
- 똑같은 모양의 스낵바 띄우는데 host부터 만들어야 한다.
- 스낵바가 뜬 후 다른 화면으로 넘어가면 스낵바가 사라진다.

https://github.com/Nexters/Boolti/assets/35232655/02977c41-4cc2-4050-b1d7-9d89c516e950

## 코멘트
- Main의 하위 컴포넌트에서만 사용 가능하다.
- 안타깝게도 스낵바 모양을 각 화면별로 커스텀하기는 어려워 보인다.
- onBackPressed와 같은 동작도 compositionLocal을 이용하여 파라미터를 없앨 수도 있을 것 같다. 다만, navController 자체를 넘기기보다는 popBackstack 기능만 넘기면 더 좋을 듯하다.