### PR TITLE
Boolti-190 feat: 공연 등록 메뉴 추가

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/my/MyScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/my/MyScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -25,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -52,6 +52,7 @@ fun MyScreen(
 ) {
     val user by viewModel.user.collectAsStateWithLifecycle()
     var openLogoutDialog by remember { mutableStateOf(false) }
+    val uriHandler = LocalUriHandler.current
 
     LaunchedEffect(Unit) {
         viewModel.fetchMyInfo()
@@ -67,17 +68,32 @@ fun MyScreen(
             text = stringResource(id = R.string.my_ticketing_history),
             onClick = if (user == null) requireLogin else navigateToReservations,
         )
-        Spacer(modifier = Modifier.height(12.dp))
         MyButton(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp),
+            text = stringResource(R.string.my_register_show),
+            onClick = {
+                if (user != null) {
+                    uriHandler.openUri("https://boolti.in/home") // 웹에서 로그인되지 않은 상태라면 login 페이지로 리다이렉션 시킴
+                } else {
+                    uriHandler.openUri("https://boolti.in/login")
+                }
+            }
+        )
+        MyButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp),
             text = stringResource(id = R.string.my_scan_qr),
             onClick = onClickQrScan,
         )
 
         if (user != null) {
-            Spacer(modifier = Modifier.height(12.dp))
             MyButton(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp),
                 text = stringResource(id = R.string.my_logout),
                 onClick = { openLogoutDialog = true },
             )

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -175,6 +175,7 @@
     <string name="my_ticketing_history">예매 내역</string>
     <string name="my_scan_qr">QR 스캔</string>
     <string name="my_logout_popup">정말 로그아웃 하시겠어요?</string>
+    <string name="my_register_show">공연 등록</string>
 
     <!-- QR 스캔 -->
     <string name="hostedShowsTitle">QR 스캔</string>


### PR DESCRIPTION
## Issue
- close #190 

## 작업 내용

마이 페이지에 공연 등록 메뉴 추가

home 으로 이동시켜도 웹에서 로그인이 안되어 있으면 로그인 화면으로 리다이렉션 침

추후 토큰 정보를 넘겨서 로그인 유지할 수 있도록 강화될 예정

<img width="397" alt="image" src="https://github.com/Nexters/Boolti/assets/44221447/d5ca0d03-68cb-4c8e-b564-9c406d99edf6">
