### PR TITLE
fix : 빈공간 생기는 문제 해결

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/show/ShowScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/show/ShowScreen.kt
@@ -163,6 +163,7 @@ fun ShowAppBar(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.background)
             .padding(horizontal = marginHorizontal)
     ) {
         Spacer(modifier = Modifier.height(20.dp))


### PR DESCRIPTION
## Issue
- close #195 

## 작업 내용
- 스크롤했을 때 앱바와 상태바 사이에 빈공간이 생기는 문제 수정

## 코멘트
- 계산상의 문제는 없는 것 같은데 왜 간격(약 2dp정도)이 생기는지는 모르겠음
