### PR TITLE
fallback url 설정

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/show/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/show/ShowDetailScreen.kt
@@ -266,11 +266,16 @@ private fun ShowDetailAppBar(
                 .size(44.dp),
             onClick = {
                 Firebase.dynamicLinks.shortLinkAsync {
-                    link = Uri.parse("https://preview.boolti.in/show/$showId")
+                    val uri = Uri.parse("https://preview.boolti.in/show/$showId")
+                    link = uri
                     domainUriPrefix = "https://boolti.page.link"
 
-                    androidParameters { }
-                    iosParameters("com.nexters.boolti") { }
+                    androidParameters {
+                        fallbackUrl = uri
+                    }
+                    iosParameters("com.nexters.boolti") {
+                        setFallbackUrl(uri)
+                    }
                 }.addOnSuccessListener {
                     it.shortLink?.let { link ->
                         println(link)


### PR DESCRIPTION
## Issue
- close #210 

## 작업 내용
- 앱 미설치시 웹 프리뷰 페이지로 이동

## 코멘트
- 앱 미설치시 preview 웹으로 넘어가게 되어 있구, 현재는 prod 서버 배포가 이후엔 데이터 로딩까지 될 예정
- iOS 에서도 잘 된다고 해~
