### PR TITLE
Boolti-238 feat: 결제 관련 약관 노션 연결 및 동의 로직 개선

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -106,6 +107,7 @@ fun TicketingScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var showConfirmDialog by remember { mutableStateOf(false) }
     val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
 
     val paymentLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -221,10 +223,16 @@ fun TicketingScreen(
                 OrderAgreementSection(
                     totalAgreed = uiState.orderAgreed,
                     agreement = uiState.orderAgreement,
-                    agreementLabels = uiState.orderAgreementInfos,
                     onClickTotalAgree = viewModel::toggleAgreement,
                     onClickAgree = viewModel::toggleAgreement,
-                    onClickShow = {}, // TODO 기획 확정되면 구현
+                    onClickShow = {
+                        val url = when (it) {
+                            0 -> "https://boolti.notion.site/00259d85983c4ba8a987a374e2615396?pvs=4"
+                            1 -> "https://boolti.notion.site/3-354880c7d75e424486b7974e5cc8bcad?pvs=4"
+                            else -> return@OrderAgreementSection
+                        }
+                        uriHandler.openUri(url)
+                    },
                 )
 
                 Text(
@@ -599,8 +607,7 @@ private fun TicketHolderSection(
 @Composable
 private fun OrderAgreementSection(
     totalAgreed: Boolean,
-    agreementLabels: List<Int>,
-    agreement: List<Boolean>,
+    agreement: List<Pair<Int, Boolean>>,
     onClickTotalAgree: () -> Unit,
     onClickAgree: (index: Int) -> Unit,
     onClickShow: (index: Int) -> Unit,
@@ -640,11 +647,11 @@ private fun OrderAgreementSection(
         }
 
         Spacer(modifier = Modifier.size(16.dp))
-        agreementLabels.forEachIndexed { index, labelRes ->
+        agreement.forEachIndexed { index, (labelRes, agreed) ->
             OrderAgreementItem(
                 modifier = Modifier.padding(top = 4.dp),
                 index = index,
-                agreed = agreement[index],
+                agreed = agreed,
                 label = stringResource(labelRes),
                 onClickAgree = onClickAgree,
                 onClickShow = onClickShow,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingState.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingState.kt
@@ -21,16 +21,13 @@ data class TicketingState(
     val depositorContact: String = "",
     val inviteCode: String = "",
     val refundPolicy: List<String> = emptyList(),
-    val orderAgreement: List<Boolean> = listOf(false, false, false),
+    val orderAgreement: List<Pair<Int, Boolean>> = listOf(
+        Pair(R.string.order_agreement_privacy_collection, false),
+        Pair(R.string.order_agreement_privacy_offer, false),
+    ),
 ) {
-    val orderAgreementInfos = listOf(
-        R.string.order_agreement_privacy_collection,
-        R.string.order_agreement_privacy_offer,
-        R.string.order_agreement_payment_agency,
-    )
-
     val orderAgreed: Boolean
-        get() = orderAgreement.none { !it }
+        get() = orderAgreement.none { !it.second }
 
     val reservationButtonEnabled: Boolean
         get() = when {
@@ -48,16 +45,16 @@ data class TicketingState(
 
     fun toggleAgreement(index: Int): TicketingState {
         val updated = orderAgreement.toMutableList().apply {
-            set(index, !orderAgreement[index])
+            set(index, orderAgreement[index].copy(second = !orderAgreement[index].second))
         }
         return copy(orderAgreement = updated)
     }
 
     fun toggleAgreement(): TicketingState {
         return if (orderAgreed) {
-            copy(orderAgreement = orderAgreement.map { false })
+            copy(orderAgreement = orderAgreement.map { it.copy(second = false) })
         } else {
-            copy(orderAgreement = orderAgreement.map { true })
+            copy(orderAgreement = orderAgreement.map { it.copy(second = true) })
         }
     }
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingState.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingState.kt
@@ -50,11 +50,5 @@ data class TicketingState(
         return copy(orderAgreement = updated)
     }
 
-    fun toggleAgreement(): TicketingState {
-        return if (orderAgreed) {
-            copy(orderAgreement = orderAgreement.map { it.copy(second = false) })
-        } else {
-            copy(orderAgreement = orderAgreement.map { it.copy(second = true) })
-        }
-    }
+    fun toggleAgreement(): TicketingState = copy(orderAgreement = orderAgreement.map { it.copy(second = !orderAgreed) })
 }


### PR DESCRIPTION
## Issue
- close #238

## 작업 내용

- 개인정보 수집 이용 동의, 개인정보 3자 제공 동의 노션 연결
- 동의 로직 개선
  - 동의 여부와 문구를 별도로 관리하지 않고 Pair 로 묶음
  - 메뉴가 하나 없어졌는데 따로 관리되다 보니 로직에 문제가 생길 뻔 함 그래서 바꿈
