### PR TITLE
Feature/boolti 298 공연 상세 UI 변경 (출연진 탭 추가)

### DIFF
--- a/data/src/main/java/com/nexters/boolti/data/datasource/ShowDataSource.kt
+++ b/data/src/main/java/com/nexters/boolti/data/datasource/ShowDataSource.kt
@@ -1,6 +1,7 @@
 package com.nexters.boolti.data.datasource
 
 import com.nexters.boolti.data.network.api.ShowService
+import com.nexters.boolti.data.network.response.CastTeamsDto
 import com.nexters.boolti.data.network.response.ShowDetailResponse
 import com.nexters.boolti.data.network.response.ShowResponse
 import javax.inject.Inject
@@ -14,5 +15,9 @@ internal class ShowDataSource @Inject constructor(
 
     suspend fun findShowById(id: String): Result<ShowDetailResponse> = runCatching {
         showService.findShowById(id)
+    }
+
+    suspend fun requestCastTeams(id: String): Result<List<CastTeamsDto>> = runCatching {
+        showService.requestCastTeams(id)
     }
 }

--- a/data/src/main/java/com/nexters/boolti/data/network/api/ShowService.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/api/ShowService.kt
@@ -1,5 +1,6 @@
 package com.nexters.boolti.data.network.api
 
+import com.nexters.boolti.data.network.response.CastTeamsDto
 import com.nexters.boolti.data.network.response.ShowDetailResponse
 import com.nexters.boolti.data.network.response.ShowResponse
 import retrofit2.http.GET
@@ -12,4 +13,7 @@ internal interface ShowService {
 
     @GET("/app/papi/v1/show/{id}")
     suspend fun findShowById(@Path("id") id: String): ShowDetailResponse
+
+    @GET("/app/papi/v1/shows/{showId}/cast-teams")
+    suspend fun requestCastTeams(@Path("showId") id: String): List<CastTeamsDto>
 }

--- a/data/src/main/java/com/nexters/boolti/data/network/response/CastTeamsDto.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/response/CastTeamsDto.kt
@@ -1,6 +1,5 @@
 package com.nexters.boolti.data.network.response
 
-import com.nexters.boolti.data.util.toLocalDateTime
 import com.nexters.boolti.domain.model.Cast
 import com.nexters.boolti.domain.model.CastTeams
 import kotlinx.serialization.Serializable
@@ -12,15 +11,11 @@ data class CastTeamsDto(
     val id: String = "",
     val name: String = "",
     val members: List<CastDto> = emptyList(),
-    val createdAt: String = LocalDateTime.MIN.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
-    val modifiedAt: String? = null,
 ) {
     fun toDomain(): CastTeams = CastTeams(
         id = id,
         teamName = name,
         members = members.map(CastDto::toDomain),
-        createdAt = createdAt.toLocalDateTime(),
-        modifiedAt = modifiedAt?.toLocalDateTime(),
     )
 
     @Serializable
@@ -39,8 +34,6 @@ data class CastTeamsDto(
             photo = userImgPath,
             nickname = userNickname,
             roleName = roleName,
-            createdAt = createdAt.toLocalDateTime(),
-            modifiedAt = modifiedAt?.toLocalDateTime(),
         )
     }
 }

--- a/data/src/main/java/com/nexters/boolti/data/network/response/CastTeamsDto.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/response/CastTeamsDto.kt
@@ -1,0 +1,46 @@
+package com.nexters.boolti.data.network.response
+
+import com.nexters.boolti.data.util.toLocalDateTime
+import com.nexters.boolti.domain.model.Cast
+import com.nexters.boolti.domain.model.CastTeams
+import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Serializable
+data class CastTeamsDto(
+    val id: String = "",
+    val name: String = "",
+    val members: List<CastDto> = emptyList(),
+    val createdAt: String = LocalDateTime.MIN.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+    val modifiedAt: String? = null,
+) {
+    fun toDomain(): CastTeams = CastTeams(
+        id = id,
+        teamName = name,
+        members = members.map(CastDto::toDomain),
+        createdAt = createdAt.toLocalDateTime(),
+        modifiedAt = modifiedAt?.toLocalDateTime(),
+    )
+
+    @Serializable
+    data class CastDto(
+        val id: String = "",
+        val userCode: String = "",
+        val userImgPath: String? = null,
+        val userNickname: String = "",
+        val roleName: String = "",
+        val createdAt: String = LocalDateTime.MIN.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+        val modifiedAt: String?,
+    ) {
+        fun toDomain(): Cast = Cast(
+            id = id,
+            userCode = userCode,
+            photo = userImgPath,
+            nickname = userNickname,
+            roleName = roleName,
+            createdAt = createdAt.toLocalDateTime(),
+            modifiedAt = modifiedAt?.toLocalDateTime(),
+        )
+    }
+}

--- a/data/src/main/java/com/nexters/boolti/data/repository/ShowRepositoryImpl.kt
+++ b/data/src/main/java/com/nexters/boolti/data/repository/ShowRepositoryImpl.kt
@@ -24,6 +24,33 @@ internal class ShowRepositoryImpl @Inject constructor(
     }
 
     override suspend fun requestCastTeams(id: String): Result<List<CastTeams>> {
+        /*return Result.success(
+            listOf(
+                CastTeams(
+                    teamName = "Salty&Sweet",
+                    members = listOf(
+                        Cast(nickname = "김불티", roleName = "보컬"),
+                        Cast(nickname = "박불티", roleName = "기타"),
+                        Cast(nickname = "이불티", roleName = "기타"),
+                        Cast(nickname = "송불티", roleName = "키보드"),
+                        Cast(nickname = "장불티", roleName = "베이스"),
+                        Cast(nickname = "최불티", roleName = "드럼"),
+                    ),
+                ),
+                CastTeams(
+                    teamName = "0v0",
+                    members = listOf(
+                        Cast(nickname = "이불티", roleName = "보컬 & 키보드"),
+                        Cast(nickname = "송불티", roleName = "보컬 & 키보드 & 드럼 & 베이스"),
+                        Cast(nickname = "장불티", roleName = "베이스"),
+                        Cast(nickname = "최불티", roleName = "드럼"),
+                    ),
+                ),
+                CastTeams(
+                    teamName = "125",
+                )
+            )
+        )*/
         return showDateSource.requestCastTeams(id).map {
             it.map { it.toDomain() }
         }

--- a/data/src/main/java/com/nexters/boolti/data/repository/ShowRepositoryImpl.kt
+++ b/data/src/main/java/com/nexters/boolti/data/repository/ShowRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.nexters.boolti.data.repository
 
 import com.nexters.boolti.data.datasource.ShowDataSource
 import com.nexters.boolti.data.network.response.toDomains
+import com.nexters.boolti.domain.model.CastTeams
 import com.nexters.boolti.domain.model.Show
 import com.nexters.boolti.domain.model.ShowDetail
 import com.nexters.boolti.domain.repository.ShowRepository
@@ -19,6 +20,12 @@ internal class ShowRepositoryImpl @Inject constructor(
     override suspend fun searchById(id: String): Result<ShowDetail> {
         return showDateSource.findShowById(id = id).map {
             it.toDomain()
+        }
+    }
+
+    override suspend fun requestCastTeams(id: String): Result<List<CastTeams>> {
+        return showDateSource.requestCastTeams(id).map {
+            it.map { it.toDomain() }
         }
     }
 }

--- a/domain/src/main/java/com/nexters/boolti/domain/model/Cast.kt
+++ b/domain/src/main/java/com/nexters/boolti/domain/model/Cast.kt
@@ -1,0 +1,21 @@
+package com.nexters.boolti.domain.model
+
+import java.time.LocalDateTime
+
+data class CastTeams(
+    val id: String = "",
+    val teamName: String = "",
+    val members: List<Cast> = emptyList(),
+    val createdAt: LocalDateTime = LocalDateTime.MIN,
+    val modifiedAt: LocalDateTime? = null,
+)
+
+data class Cast(
+    val id: String = "",
+    val userCode: String = "",
+    val photo: String? = null,
+    val nickname: String = "",
+    val roleName: String = "",
+    val createdAt: LocalDateTime = LocalDateTime.MIN,
+    val modifiedAt: LocalDateTime? = null,
+)

--- a/domain/src/main/java/com/nexters/boolti/domain/model/Cast.kt
+++ b/domain/src/main/java/com/nexters/boolti/domain/model/Cast.kt
@@ -1,13 +1,9 @@
 package com.nexters.boolti.domain.model
 
-import java.time.LocalDateTime
-
 data class CastTeams(
     val id: String = "",
     val teamName: String = "",
     val members: List<Cast> = emptyList(),
-    val createdAt: LocalDateTime = LocalDateTime.MIN,
-    val modifiedAt: LocalDateTime? = null,
 )
 
 data class Cast(
@@ -16,6 +12,4 @@ data class Cast(
     val photo: String? = null,
     val nickname: String = "",
     val roleName: String = "",
-    val createdAt: LocalDateTime = LocalDateTime.MIN,
-    val modifiedAt: LocalDateTime? = null,
 )

--- a/domain/src/main/java/com/nexters/boolti/domain/repository/ShowRepository.kt
+++ b/domain/src/main/java/com/nexters/boolti/domain/repository/ShowRepository.kt
@@ -1,9 +1,11 @@
 package com.nexters.boolti.domain.repository
 
+import com.nexters.boolti.domain.model.CastTeams
 import com.nexters.boolti.domain.model.Show
 import com.nexters.boolti.domain.model.ShowDetail
 
 interface ShowRepository {
     suspend fun search(keyword: String): Result<List<Show>>
     suspend fun searchById(id: String): Result<ShowDetail>
+    suspend fun requestCastTeams(showId: String): Result<List<CastTeams>>
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/UserThumbnail.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/UserThumbnail.kt
@@ -1,0 +1,42 @@
+package com.nexters.boolti.presentation.component
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.nexters.boolti.presentation.R
+
+@Composable
+fun UserThumbnail(
+    size: Dp,
+    thumbnailUrl: String?,
+    modifier: Modifier = Modifier,
+    defaultImage: Int = R.drawable.ic_fallback_profile,
+    outlineColor: Color = MaterialTheme.colorScheme.outline,
+    contentDescription: String? = null,
+) {
+    AsyncImage(
+        modifier = modifier
+            .size(size)
+            .clip(shape = CircleShape)
+            .border(
+                width = 1.dp,
+                color = outlineColor,
+                shape = CircleShape,
+            ),
+        model = thumbnailUrl,
+        contentDescription = contentDescription,
+        placeholder = painterResource(id = defaultImage),
+        fallback = painterResource(id = defaultImage),
+        contentScale = ContentScale.Crop,
+    )
+}

--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/UserThumbnail.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/UserThumbnail.kt
@@ -18,7 +18,7 @@ import com.nexters.boolti.presentation.R
 @Composable
 fun UserThumbnail(
     size: Dp,
-    thumbnailUrl: String?,
+    model: Any?,
     modifier: Modifier = Modifier,
     defaultImage: Int = R.drawable.ic_fallback_profile,
     outlineColor: Color = MaterialTheme.colorScheme.outline,
@@ -33,7 +33,7 @@ fun UserThumbnail(
                 color = outlineColor,
                 shape = CircleShape,
             ),
-        model = thumbnailUrl,
+        model = model,
         contentDescription = contentDescription,
         placeholder = painterResource(id = defaultImage),
         fallback = painterResource(id = defaultImage),

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/my/MyScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/my/MyScreen.kt
@@ -2,7 +2,6 @@ package com.nexters.boolti.presentation.screen.my
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,7 +12,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
@@ -28,9 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
@@ -41,11 +37,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
 import com.nexters.boolti.domain.model.User
 import com.nexters.boolti.presentation.BuildConfig
 import com.nexters.boolti.presentation.R
 import com.nexters.boolti.presentation.component.SmallButton
+import com.nexters.boolti.presentation.component.UserThumbnail
 import com.nexters.boolti.presentation.theme.BooltiTheme
 import com.nexters.boolti.presentation.theme.Grey30
 import com.nexters.boolti.presentation.theme.Grey80
@@ -125,7 +121,10 @@ fun MyScreen(
                     )
 
                     HorizontalDivider(
-                        modifier = Modifier.padding(vertical = 32.dp, horizontal = marginHorizontal),
+                        modifier = Modifier.padding(
+                            vertical = 32.dp,
+                            horizontal = marginHorizontal,
+                        ),
                         color = MaterialTheme.colorScheme.surfaceTint,
                     )
 
@@ -193,21 +192,10 @@ private fun MyHeader(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         user?.let {
-            AsyncImage(
-                modifier = Modifier
-                    .padding(end = 12.dp)
-                    .size(36.dp)
-                    .clip(shape = CircleShape)
-                    .border(
-                        width = 1.dp,
-                        color = MaterialTheme.colorScheme.outline,
-                        shape = CircleShape,
-                    ),
-                model = user.photo,
-                contentDescription = null,
-                placeholder = painterResource(id = R.drawable.ic_fallback_profile),
-                fallback = painterResource(id = R.drawable.ic_fallback_profile),
-                contentScale = ContentScale.Crop,
+            UserThumbnail(
+                modifier = Modifier.padding(end = 12.dp),
+                size = 36.dp,
+                thumbnailUrl = user.photo,
             )
         }
         Text(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/my/MyScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/my/MyScreen.kt
@@ -195,7 +195,7 @@ private fun MyHeader(
             UserThumbnail(
                 modifier = Modifier.padding(end = 12.dp),
                 size = 36.dp,
-                thumbnailUrl = user.photo,
+                model = user.photo,
             )
         }
         Text(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/profile/ProfileScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/profile/ProfileScreen.kt
@@ -2,7 +2,6 @@ package com.nexters.boolti.presentation.screen.profile
 
 import android.content.ActivityNotFoundException
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
@@ -24,9 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
@@ -34,13 +30,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
 import com.nexters.boolti.domain.model.Link
 import com.nexters.boolti.domain.model.User
 import com.nexters.boolti.presentation.R
 import com.nexters.boolti.presentation.component.BtAppBarDefaults
 import com.nexters.boolti.presentation.component.BtBackAppBar
 import com.nexters.boolti.presentation.component.SmallButton
+import com.nexters.boolti.presentation.component.UserThumbnail
 import com.nexters.boolti.presentation.extension.toValidUrlString
 import com.nexters.boolti.presentation.screen.LocalSnackbarController
 import com.nexters.boolti.presentation.theme.Grey30
@@ -148,21 +144,10 @@ private fun ProfileHeader(
             .padding(horizontal = marginHorizontal)
             .padding(bottom = 32.dp),
     ) {
-        AsyncImage(
-            modifier = Modifier
-                .padding(top = 40.dp)
-                .size(70.dp)
-                .clip(shape = CircleShape)
-                .border(
-                    width = 1.dp,
-                    color = MaterialTheme.colorScheme.outline,
-                    shape = CircleShape,
-                ),
-            model = user.photo,
-            contentDescription = null,
-            placeholder = painterResource(id = R.drawable.ic_fallback_profile),
-            fallback = painterResource(id = R.drawable.ic_fallback_profile),
-            contentScale = ContentScale.Crop,
+        UserThumbnail(
+            modifier = Modifier.padding(top = 40.dp),
+            size = 70.dp,
+            thumbnailUrl = user.photo,
         )
         Text(
             modifier = Modifier.padding(top = 20.dp),

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/profile/ProfileScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/profile/ProfileScreen.kt
@@ -147,7 +147,7 @@ private fun ProfileHeader(
         UserThumbnail(
             modifier = Modifier.padding(top = 40.dp),
             size = 70.dp,
-            thumbnailUrl = user.photo,
+            model = user.photo,
         )
         Text(
             modifier = Modifier.padding(top = 20.dp),

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/profileedit/profile/ProfileEditScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/profileedit/profile/ProfileEditScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -51,7 +50,6 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
 import com.nexters.boolti.domain.model.Link
 import com.nexters.boolti.presentation.R
 import com.nexters.boolti.presentation.component.BTDialog
@@ -59,6 +57,7 @@ import com.nexters.boolti.presentation.component.BTTextField
 import com.nexters.boolti.presentation.component.BtAppBar
 import com.nexters.boolti.presentation.component.BtAppBarDefaults
 import com.nexters.boolti.presentation.component.BtCircularProgressIndicator
+import com.nexters.boolti.presentation.component.UserThumbnail
 import com.nexters.boolti.presentation.extension.takeForUnicode
 import com.nexters.boolti.presentation.screen.LocalSnackbarController
 import com.nexters.boolti.presentation.theme.Grey15
@@ -222,16 +221,10 @@ fun ProfileEditScreen(
                         .height(180.dp),
                 ) {
                     val (thumbnailImg, cameraIcon) = createRefs()
-                    AsyncImage(
-                        modifier = Modifier
-                            .constrainAs(thumbnailImg) {
-                                centerTo(parent)
-                            }
-                            .size(100.dp)
-                            .clip(CircleShape)
-                            .border(1.dp, MaterialTheme.colorScheme.outline, CircleShape),
+                    UserThumbnail(
+                        modifier = Modifier.constrainAs(thumbnailImg) { centerTo(parent) },
+                        size = 100.dp,
                         model = selectedImage ?: thumbnail,
-                        contentScale = ContentScale.Crop,
                         contentDescription = stringResource(R.string.description_user_thumbnail),
                     )
                     Surface(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
@@ -26,6 +26,10 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -63,6 +67,7 @@ import com.nexters.boolti.presentation.screen.ticketing.TicketBottomSheetType
 import com.nexters.boolti.presentation.theme.Grey20
 import com.nexters.boolti.presentation.theme.Grey30
 import com.nexters.boolti.presentation.theme.Grey50
+import com.nexters.boolti.presentation.theme.Grey70
 import com.nexters.boolti.presentation.theme.Grey80
 import com.nexters.boolti.presentation.theme.Grey85
 import com.nexters.boolti.presentation.theme.marginHorizontal
@@ -149,6 +154,18 @@ fun ShowDetailScreen(
                     title = uiState.showDetail.name,
                     images = uiState.showDetail.images.map { it.originImage }
                 )
+
+                TicketReservationPeriod(
+                    modifier = Modifier.padding(vertical = 40.dp, horizontal = 20.dp),
+                    startDate = uiState.showDetail.salesStartDate,
+                    endDate = uiState.showDetail.salesEndDate,
+                )
+
+                ContentTabRow(
+                    selectedTabIndex = uiState.selectedTab,
+                    onSelectTab = viewModel::selectTab,
+                )
+
                 ContentScaffold(
                     modifier = Modifier
                         .padding(horizontal = marginHorizontal)
@@ -289,6 +306,76 @@ private fun ShowDetailAppBar(
 }
 
 @Composable
+private fun ContentTabRow(
+    modifier: Modifier = Modifier,
+    selectedTabIndex: Int = 0,
+    onSelectTab: (index: Int) -> Unit = {},
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        HorizontalDivider(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth(),
+            thickness = 1.dp,
+            color = Grey85,
+        )
+        TabRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+            selectedTabIndex = selectedTabIndex,
+            containerColor = Color.Transparent,
+            indicator = { tabPositions ->
+                if (selectedTabIndex < tabPositions.size) {
+                    TabRowDefaults.SecondaryIndicator(
+                        modifier = Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            },
+            divider = {},
+        ) {
+            ContentTab(
+                selected = selectedTabIndex == 0,
+                label = stringResource(R.string.show_tab_info),
+                onSelect = { onSelectTab(0) },
+            )
+            ContentTab(
+                selected = selectedTabIndex == 1,
+                label = stringResource(R.string.show_tab_cast),
+                onSelect = { onSelectTab(1) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ContentTab(
+    modifier: Modifier = Modifier,
+    selected: Boolean,
+    label: String,
+    onSelect: () -> Unit,
+) {
+    Tab(
+        modifier = modifier,
+        selected = selected,
+        selectedContentColor = MaterialTheme.colorScheme.onSurface,
+        unselectedContentColor = Grey70,
+        text = {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleMedium,
+            )
+        },
+        onClick = onSelect,
+    )
+}
+
+@Composable
 private fun ContentScaffold(
     showDetail: ShowDetail,
     host: String,
@@ -300,11 +387,7 @@ private fun ContentScaffold(
     Column(
         modifier = modifier,
     ) {
-        TicketReservationPeriod(
-            modifier = Modifier.padding(top = 40.dp),
-            startDate = showDetail.salesStartDate,
-            endDate = showDetail.salesEndDate,
-        )
+
 
         // 일시
         val daysOfWeek = stringArrayResource(id = R.array.days_of_week)

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
@@ -654,7 +654,7 @@ private fun Cast(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         UserThumbnail(
-            thumbnailUrl = member.photo,
+            model = member.photo,
             size = 46.dp,
             contentDescription = member.nickname,
         )

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
@@ -1,7 +1,6 @@
 package com.nexters.boolti.presentation.screen.showdetail
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
@@ -22,9 +21,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Divider
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -318,7 +317,7 @@ private fun ContentScaffold(
             title = { SectionTitle(stringResource(id = R.string.ticketing_datetime)) },
             content = { SectionContent(text = showDetail.date.format(formatter)) },
         )
-        Divider(color = Grey85)
+        Divider()
 
         // 장소
         Section(
@@ -353,7 +352,7 @@ private fun ContentScaffold(
                 }
             },
         )
-        Divider(color = Grey85)
+        Divider()
 
         // 공연 내용
         Section(
@@ -377,7 +376,7 @@ private fun ContentScaffold(
                 )
             },
         )
-        Divider(color = Grey85)
+        Divider()
 
         // 주최자
         Section(
@@ -469,4 +468,9 @@ private fun SectionContent(
 
         uriHandler.openUri(url)
     }
+}
+
+@Composable
+private fun Divider() {
+    HorizontalDivider(color = Grey85)
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
@@ -512,7 +512,8 @@ fun LazyListScope.CastTab(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 117.dp),
+                    .height(290.dp),
+                verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailUiState.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailUiState.kt
@@ -1,7 +1,10 @@
 package com.nexters.boolti.presentation.screen.showdetail
 
+import com.nexters.boolti.domain.model.CastTeams
 import com.nexters.boolti.domain.model.ShowDetail
 
 data class ShowDetailUiState(
     val showDetail: ShowDetail = ShowDetail(),
+    val selectedTab: Int = 0,
+    val castTeams: List<CastTeams> = emptyList(),
 )

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailViewModel.kt
@@ -1,6 +1,5 @@
 package com.nexters.boolti.presentation.screen.showdetail
 
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -67,7 +66,6 @@ class ShowDetailViewModel @Inject constructor(
             showRepository.requestCastTeams(showId = showId)
                 .onSuccess { newCastTeams ->
                     _uiState.update { it.copy(castTeams = newCastTeams) }
-                    Log.d("[MANGBAAM]ShowDetailViewModel", "fetchCastTeams: $newCastTeams")
                 }
                 .onFailure {
                     Firebase.crashlytics.recordException(it)

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailViewModel.kt
@@ -1,5 +1,6 @@
 package com.nexters.boolti.presentation.screen.showdetail
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -43,6 +44,7 @@ class ShowDetailViewModel @Inject constructor(
 
     init {
         fetchShowDetail()
+        fetchCastTeams()
     }
 
     fun sendEvent(event: ShowDetailEvent) = viewModelScope.launch { _events.send(event) }
@@ -58,6 +60,24 @@ class ShowDetailViewModel @Inject constructor(
                     Timber.e(it)
                 }
         }
+    }
+
+    private fun fetchCastTeams() {
+        viewModelScope.launch {
+            showRepository.requestCastTeams(showId = showId)
+                .onSuccess { newCastTeams ->
+                    _uiState.update { it.copy(castTeams = newCastTeams) }
+                    Log.d("[MANGBAAM]ShowDetailViewModel", "fetchCastTeams: $newCastTeams")
+                }
+                .onFailure {
+                    Firebase.crashlytics.recordException(it)
+                    Timber.e(it)
+                }
+        }
+    }
+
+    fun selectTab(index: Int) {
+        _uiState.update { it.copy(selectedTab = index.coerceIn(0 .. 1)) }
     }
 
     fun preventEvents() {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -217,6 +217,8 @@
     <string name="show_text_to_ask">문자 문의하기</string>
     <string name="show_tab_info">공연 정보</string>
     <string name="show_tab_cast">출연진</string>
+    <string name="empty_cast_title">COMING SOON</string>
+    <string name="empty_cast_desc">조금만 기다려주세요!</string>
 
     <!-- 입장 코드 -->
     <string name="manager_code">입장 코드</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -215,6 +215,8 @@
     <!-- 공연 -->
     <string name="show_call_to_ask">전화 문의하기</string>
     <string name="show_text_to_ask">문자 문의하기</string>
+    <string name="show_tab_info">공연 정보</string>
+    <string name="show_tab_cast">출연진</string>
 
     <!-- 입장 코드 -->
     <string name="manager_code">입장 코드</string>


### PR DESCRIPTION
## Issue
- close #298 

## 작업 내용

- 공연 상세 UI 변경
  - 출연진 탭 추가
- 공연 상세 `Column` → `LazyColumn` 리팩터링
- 유저 섬네일 컴포저블 컴포넌트화 (`UserThumbnail`)
  - 프로필, 마이 탭, 프로필 수정에서 `UserThumbnail` 로 대체
  - 공연 상세 출연진에서도 사용

<img width="300" alt="image" src="https://github.com/user-attachments/assets/da555da2-6ebd-4ff9-bd76-2277404ce7dc">

<img width="300" alt="image" src="https://github.com/user-attachments/assets/562f1d3b-0849-491f-a9ff-70a4e1c159e8">
