### PR TITLE
Boolti-309 fix: 토스 페이먼츠 OrderName 인코딩 버그 패치

### DIFF
--- a/tosspayments/src/main/java/com/nexters/boolti/tosspayments/TossPaymentWidgetActivity.kt
+++ b/tosspayments/src/main/java/com/nexters/boolti/tosspayments/TossPaymentWidgetActivity.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.nexters.boolti.tosspayments.databinding.ActivityTossPaymentWidgetBinding
+import com.nexters.boolti.tosspayments.extension.percentEncode
 import com.nexters.boolti.tosspayments.extension.toCurrency
 import com.tosspayments.paymentsdk.PaymentWidget
 import com.tosspayments.paymentsdk.model.AgreementStatus
@@ -259,7 +260,7 @@ class TossPaymentWidgetActivity : AppCompatActivity() {
                 .putExtra(EXTRA_KEY_CLIENT_KEY, clientKey)
                 .putExtra(EXTRA_KEY_CUSTOMER_KEY, customerKey)
                 .putExtra(EXTRA_KEY_ORDER_ID, orderId)
-                .putExtra(EXTRA_KEY_ORDER_NAME, orderName)
+                .putExtra(EXTRA_KEY_ORDER_NAME, orderName.percentEncode())
                 .putExtra(EXTRA_KEY_CURRENCY, currency.toCurrency())
                 .putExtra(EXTRA_KEY_COUNTRY_CODE, countryCode)
                 .putExtra(EXTRA_KEY_VARIANT_KEY, variantKey)
@@ -298,7 +299,7 @@ class TossPaymentWidgetActivity : AppCompatActivity() {
                 .putExtra(EXTRA_KEY_CLIENT_KEY, clientKey)
                 .putExtra(EXTRA_KEY_CUSTOMER_KEY, customerKey)
                 .putExtra(EXTRA_KEY_ORDER_ID, orderId)
-                .putExtra(EXTRA_KEY_ORDER_NAME, orderName)
+                .putExtra(EXTRA_KEY_ORDER_NAME, orderName.percentEncode())
                 .putExtra(EXTRA_KEY_CURRENCY, currency.toCurrency())
                 .putExtra(EXTRA_KEY_COUNTRY_CODE, countryCode)
                 .putExtra(EXTRA_KEY_SHOW_ID, showId)

--- a/tosspayments/src/main/java/com/nexters/boolti/tosspayments/extension/String.kt
+++ b/tosspayments/src/main/java/com/nexters/boolti/tosspayments/extension/String.kt
@@ -1,0 +1,47 @@
+package com.nexters.boolti.tosspayments.extension
+
+private val encodingMap = mapOf(
+    ':' to "%3A",
+    '/' to "%2F",
+    '?' to "%3F",
+    '#' to "%23",
+    '[' to "%5B",
+    ']' to "%5D",
+    '@' to "%40",
+    '!' to "%21",
+    '$' to "%24",
+    '&' to "%26",
+    '\'' to "%27",
+    '(' to "%28",
+    ')' to "%29",
+    '*' to "%2A",
+    '+' to "%2B",
+    ',' to "%2C",
+    ';' to "%3B",
+    '=' to "%3D",
+    '%' to "%25",
+    ' ' to "+"
+)
+
+private val decodingMap = encodingMap.map { it.value to it.key }.toMap()
+
+fun String.percentEncode(): String = fold(StringBuilder()) { sb, c ->
+    sb.append(encodingMap.getOrDefault(c, c))
+}.toString()
+
+fun String.percentDecode(): String {
+    val stringBuilder = StringBuilder()
+    var i = 0
+    while (i < this.length) {
+        if (this[i] == '%' && i + 2 < this.length) {
+            val encodedValue = this.substring(i, i + 3)
+            val decodedChar = decodingMap.getOrDefault(encodedValue, encodedValue)
+            stringBuilder.append(decodedChar)
+            i += 3
+        } else {
+            stringBuilder.append(this[i])
+            i++
+        }
+    }
+    return stringBuilder.toString()
+}


### PR DESCRIPTION
Percent Encoding

https://docs.tosspayments.com/reference/using-api/req-res#url-인코딩

https://developer.mozilla.org/ko/docs/Glossary/Percent-encoding

`'` 특수문자 포함된 공연에서 결제 창 띄워지지 않는 문제 해결

## Issue
- close #309

## 작업 내용

![image](https://github.com/user-attachments/assets/241ae555-a261-4fbd-9ad4-722f1576ef41)

