### PR TITLE
fix : 이미지 통짜로 변경

### DIFF
--- a/data/src/main/java/com/nexters/boolti/data/datasource/GiftDataSource.kt
+++ b/data/src/main/java/com/nexters/boolti/data/datasource/GiftDataSource.kt
@@ -4,6 +4,7 @@ import com.nexters.boolti.data.network.api.GiftService
 import com.nexters.boolti.data.network.request.GiftCancelRequest
 import com.nexters.boolti.data.network.request.GiftReceiveRequest
 import com.nexters.boolti.data.network.response.ApproveGiftPaymentResponse
+import com.nexters.boolti.data.network.response.GiftImageResponse
 import com.nexters.boolti.data.network.response.GiftPaymentInfoResponse
 import com.nexters.boolti.data.network.response.GiftResponse
 import com.nexters.boolti.data.network.response.ImageResponse
@@ -24,7 +25,7 @@ internal class GiftDataSource @Inject constructor(
 
     suspend fun getGift(giftUuid: String): GiftResponse = service.getGift(giftUuid)
 
-    suspend fun getGiftImages(): List<ImageResponse> = service.getGiftImages()
+    suspend fun getGiftImages(): List<GiftImageResponse> = service.getGiftImages()
 
     suspend fun getGiftPaymentInfo(giftId: String): GiftPaymentInfoResponse =
         service.getGiftPaymentInfo(giftId)

--- a/data/src/main/java/com/nexters/boolti/data/network/api/GiftService.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/api/GiftService.kt
@@ -3,6 +3,7 @@ package com.nexters.boolti.data.network.api
 import com.nexters.boolti.data.network.request.GiftCancelRequest
 import com.nexters.boolti.data.network.request.GiftReceiveRequest
 import com.nexters.boolti.data.network.response.ApproveGiftPaymentResponse
+import com.nexters.boolti.data.network.response.GiftImageResponse
 import com.nexters.boolti.data.network.response.GiftPaymentInfoResponse
 import com.nexters.boolti.data.network.response.GiftResponse
 import com.nexters.boolti.data.network.response.ImageResponse
@@ -27,7 +28,7 @@ internal interface GiftService {
     suspend fun getGift(@Path("giftUuid") giftUuid: String): GiftResponse
 
     @GET("/app/api/v1/gift/img-list")
-    suspend fun getGiftImages(): List<ImageResponse>
+    suspend fun getGiftImages(): List<GiftImageResponse>
 
     @GET("app/api/v1/gift/approve-payment-info/{giftId}")
     suspend fun getGiftPaymentInfo(@Path("giftId") giftId: String): GiftPaymentInfoResponse

--- a/data/src/main/java/com/nexters/boolti/data/network/response/GiftImageResponse.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/response/GiftImageResponse.kt
@@ -1,0 +1,28 @@
+package com.nexters.boolti.data.network.response
+
+import com.nexters.boolti.domain.model.ImagePair
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class GiftImageResponse(
+    val id: String,
+    val path: String,
+    @SerialName("preview_path") val thumbnailPath: String,
+    val sequence: Int,
+) {
+    fun toDomain(): ImagePair {
+        return ImagePair(
+            id = id,
+            originImage = path,
+            thumbnailImage = thumbnailPath,
+        )
+    }
+}
+
+internal fun List<GiftImageResponse>.toDomains(): List<ImagePair> {
+    return this.asSequence()
+        .sortedBy { it.sequence }
+        .map { it.toDomain() }
+        .toList()
+}

--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/DummyDatas.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/DummyDatas.kt
@@ -1,0 +1,43 @@
+package com.nexters.boolti.presentation.component
+
+import com.nexters.boolti.domain.model.PaymentType
+import com.nexters.boolti.domain.model.ReservationDetail
+import com.nexters.boolti.domain.model.ReservationDetail.CardDetail
+import com.nexters.boolti.domain.model.ReservationState
+import java.time.LocalDateTime
+
+/**
+ * Preview를 위한 더미 데이터들
+ */
+
+val dummyCardDetail = CardDetail(
+    installmentPlanMonths = 0,
+    issuerCode = "",
+)
+
+val dummyReservationDetail = ReservationDetail(
+    id = "12",
+    showImage = "",
+    showName = "Netflix 너무 비싸",
+    showDate = LocalDateTime.MIN,
+    giftUuid = "ab12-cd34",
+    giftInviteImage = "",
+    ticketName = "인섬니아",
+    isInviteTicket = false,
+    ticketCount = 1,
+    bankName = "카카오 뱅크 가고 싶다",
+    accountNumber = "352-2345-3456-13",
+    accountHolder = "공주영",
+    salesEndDateTime = LocalDateTime.MIN,
+    paymentType = PaymentType.CARD,
+    totalAmountPrice = 7000,
+    reservationState = ReservationState.RESERVED,
+    completedDateTime = LocalDateTime.MIN,
+    visitorName = "왕자림",
+    visitorPhoneNumber = "010-2048-1024",
+    depositorName = "공주영",
+    depositorPhoneNumber = "010-2048-4096",
+    csReservationId = "cs-65535",
+    cardDetail = dummyCardDetail,
+    provider = ""
+)

--- a/presentation/src/main/java/com/nexters/boolti/presentation/reservationdetail/ReservationDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/reservationdetail/ReservationDetailScreen.kt
@@ -326,6 +326,7 @@ private fun TicketHolderInfo(
             if (isGift && reservation.reservationState != ReservationState.CANCELED) {
                 val month = reservation.salesEndDateTime.month.value
                 val day = reservation.salesEndDateTime.dayOfMonth
+                val senderText = stringResource(id = R.string.gift_sender_description, reservation?.depositorName ?: "")
                 val dateText = stringResource(id = R.string.gift_expiration_date, month, day)
                 val buttonText = stringResource(id = R.string.gift_check)
 
@@ -336,7 +337,7 @@ private fun TicketHolderInfo(
                             sendMessage(
                                 context = context,
                                 giftUuid = reservation.giftUuid!!,
-                                receiverName = reservation.visitorName,
+                                senderText = senderText,
                                 image = reservation.giftInviteImage,
                                 dateText = dateText,
                                 buttonText = buttonText

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/CardSelection.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/CardSelection.kt
@@ -1,11 +1,14 @@
 package com.nexters.boolti.presentation.screen.gift
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -59,9 +62,9 @@ fun CardSelection(
                 )
         ) {
             AsyncImage(
+                modifier = Modifier.aspectRatio(311 / 394f), // 선물 이미지 사이즈
                 model = selectedImage?.originImage,
                 contentDescription = stringResource(id = R.string.gift_selected_image),
-                modifier = Modifier.fillMaxWidth(),
                 contentScale = ContentScale.Crop,
             )
 
@@ -115,31 +118,40 @@ private fun CardCarousel(
 ) {
     LazyRow(
         modifier = modifier,
-        contentPadding = PaddingValues(start = 32.dp),
+        contentPadding = PaddingValues(horizontal = 32.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         items(images) { image ->
-            val cardModifier = if (image == selectedImage) {
-                Modifier.border(
-                    width = 1.dp,
-                    color = MaterialTheme.colorScheme.primary,
-                    shape = RoundedCornerShape(4.dp)
-                )
-            } else {
-                Modifier
-            }
-
-            AsyncImage(
-                model = image.thumbnailImage,
-                contentDescription = stringResource(id = R.string.gift_image),
-                modifier = cardModifier
+            Box(
+                modifier = Modifier
                     .size(52.dp)
                     .clip(RoundedCornerShape(4.dp))
                     .clickable {
                         onImageSelected(image)
-                    },
-                contentScale = ContentScale.Crop,
-            )
+                    }
+            ) {
+                AsyncImage(
+                    model = image.thumbnailImage,
+                    contentDescription = stringResource(id = R.string.gift_image),
+                    contentScale = ContentScale.Crop,
+                )
+
+                if (image == selectedImage) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .border(
+                                width = 2.dp,
+                                color = MaterialTheme.colorScheme.primary,
+                                shape = RoundedCornerShape(4.dp)
+                            )
+                            .background(
+                                color = Color.Black.copy(alpha = 0.45f),
+                                shape = RoundedCornerShape(4.dp)
+                            )
+                    )
+                }
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/CardSelection.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/CardSelection.kt
@@ -71,7 +71,9 @@ fun CardSelection(
                 )
         ) {
             AsyncImage(
-                modifier = Modifier.aspectRatio(311 / 394f), // 선물 이미지 사이즈
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(311 / 394f), // 선물 이미지 사이즈
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(selectedImage?.originImage)
                     .crossfade(true)

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/CardSelection.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/CardSelection.kt
@@ -1,12 +1,11 @@
 package com.nexters.boolti.presentation.screen.gift
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -21,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
@@ -49,58 +47,52 @@ fun CardSelection(
     Column(
         modifier = Modifier.padding(top = 24.dp, bottom = 48.dp),
     ) {
-        Column(
+        // 이미지 영역
+        Box(
             modifier = Modifier
                 .padding(horizontal = 32.dp)
                 .clip(RoundedCornerShape(8.dp))
-                .background(
-                    brush = Brush.verticalGradient(
-                        colors = listOf(
-                            Color(0xFFFF5A14),
-                            Color(0xFFFFA883),
-                        )
-                    )
-                )
                 .border(
                     width = 1.dp,
-                    color = Color(0xFFFFA883),
+                    color = Color.White.copy(alpha = 0.4f),
                     shape = RoundedCornerShape(8.dp)
                 )
-                .padding(top = 32.dp)
-                .padding(horizontal = 20.dp)
-                .fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            val maximumLength = 40
-            val messageLengthUnit = stringResource(id = R.string.gift_message_length_unit)
-
-            BasicTextField(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(80.dp),
-                value = message,
-                onValueChange = onMessageChanged,
-                textStyle = MaterialTheme.typography.titleLarge.copy(
-                    color = Color.White,
-                    textAlign = TextAlign.Center
-                ),
-                cursorBrush = SolidColor(Color.White)
-            )
-            Text(
-                modifier = Modifier.padding(top = 12.dp),
-                text = "${message.length}/${maximumLength}${messageLengthUnit}",
-                style = MaterialTheme.typography.labelMedium.copy(color = Grey10),
-            )
-
             AsyncImage(
                 model = selectedImage?.originImage,
                 contentDescription = stringResource(id = R.string.gift_selected_image),
-                modifier = Modifier
-                    .padding(top = 28.dp)
-                    .fillMaxWidth()
-                    .background(Color.White),
+                modifier = Modifier.fillMaxWidth(),
                 contentScale = ContentScale.Crop,
             )
+
+            Column(
+                modifier = Modifier
+                    .padding(top = 32.dp)
+                    .padding(horizontal = 20.dp)
+                    .fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                val maximumLength = 40
+                val messageLengthUnit = stringResource(id = R.string.gift_message_length_unit)
+
+                BasicTextField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(80.dp),
+                    value = message,
+                    onValueChange = onMessageChanged,
+                    textStyle = MaterialTheme.typography.titleLarge.copy(
+                        color = Color.White,
+                        textAlign = TextAlign.Center
+                    ),
+                    cursorBrush = SolidColor(Color.White)
+                )
+                Text(
+                    modifier = Modifier.padding(top = 12.dp),
+                    text = "${message.length}/${maximumLength}${messageLengthUnit}",
+                    style = MaterialTheme.typography.labelMedium.copy(color = Grey10),
+                )
+            }
         }
 
         CardCarousel(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/CardSelection.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/CardSelection.kt
@@ -20,17 +20,24 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import coil.compose.AsyncImagePainter
+import coil.request.ImageRequest
 import com.nexters.boolti.domain.model.ImagePair
 import com.nexters.boolti.presentation.R
 import com.nexters.boolti.presentation.theme.BooltiTheme
@@ -47,6 +54,8 @@ fun CardSelection(
     selectedImage: ImagePair?,
     onImageSelected: (ImagePair) -> Unit,
 ) {
+    var showBorder by remember { mutableStateOf(false) }
+
     Column(
         modifier = Modifier.padding(top = 24.dp, bottom = 48.dp),
     ) {
@@ -56,16 +65,22 @@ fun CardSelection(
                 .padding(horizontal = 32.dp)
                 .clip(RoundedCornerShape(8.dp))
                 .border(
-                    width = 1.dp,
+                    width = if (showBorder) 1.dp else 0.dp,
                     color = Color.White.copy(alpha = 0.4f),
                     shape = RoundedCornerShape(8.dp)
                 )
         ) {
             AsyncImage(
                 modifier = Modifier.aspectRatio(311 / 394f), // 선물 이미지 사이즈
-                model = selectedImage?.originImage,
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(selectedImage?.originImage)
+                    .crossfade(true)
+                    .build(),
                 contentDescription = stringResource(id = R.string.gift_selected_image),
                 contentScale = ContentScale.Crop,
+                onState = { state ->
+                    showBorder = state is AsyncImagePainter.State.Success
+                }
             )
 
             Column(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/GiftScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/GiftScreen.kt
@@ -1,9 +1,5 @@
 package com.nexters.boolti.presentation.screen.gift
 
-import android.annotation.SuppressLint
-import android.view.ViewGroup
-import android.webkit.WebView
-import android.webkit.WebViewClient
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -16,12 +12,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,7 +25,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -41,7 +33,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nexters.boolti.domain.model.Currency

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/GiftScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/GiftScreen.kt
@@ -67,7 +67,6 @@ import com.nexters.boolti.tosspayments.TossPaymentWidgetActivity.Companion.RESUL
 import com.nexters.boolti.tosspayments.TossPaymentWidgetActivity.Companion.RESULT_SOLD_OUT
 import com.nexters.boolti.tosspayments.TossPaymentWidgetActivity.Companion.RESULT_SUCCESS
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GiftScreen(
     popBackStack: () -> Unit,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/giftcomplete/GiftCompleteScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/giftcomplete/GiftCompleteScreen.kt
@@ -3,12 +3,10 @@ package com.nexters.boolti.presentation.screen.giftcomplete
 import android.content.Context
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -22,6 +20,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -29,13 +28,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -50,9 +49,11 @@ import com.nexters.boolti.domain.model.ReservationDetail
 import com.nexters.boolti.presentation.BuildConfig
 import com.nexters.boolti.presentation.R
 import com.nexters.boolti.presentation.component.SecondaryButton
+import com.nexters.boolti.presentation.component.dummyReservationDetail
 import com.nexters.boolti.presentation.extension.cardCodeToCompanyName
 import com.nexters.boolti.presentation.screen.payment.PaymentToolbar
 import com.nexters.boolti.presentation.screen.payment.TicketSummarySection
+import com.nexters.boolti.presentation.theme.BooltiTheme
 import com.nexters.boolti.presentation.theme.Grey15
 import com.nexters.boolti.presentation.theme.Grey30
 import com.nexters.boolti.presentation.theme.Grey40
@@ -70,8 +71,24 @@ fun GiftCompleteScreen(
     onClickClose: () -> Unit,
     navigateToReservation: (reservation: ReservationDetail) -> Unit,
     viewModel: GiftCompleteViewModel = hiltViewModel(),
-) {
+)  {
     val reservation by viewModel.reservation.collectAsStateWithLifecycle()
+
+    GiftCompleteScreen(
+        onClickHome = onClickHome,
+        onClickClose = onClickClose,
+        navigateToReservation = navigateToReservation,
+        reservation = reservation,
+    )
+}
+
+@Composable
+fun GiftCompleteScreen(
+    onClickHome: () -> Unit,
+    onClickClose: () -> Unit,
+    navigateToReservation: (reservation: ReservationDetail) -> Unit,
+    reservation: ReservationDetail?,
+) {
     val context = LocalContext.current
 
     BackHandler(onBack = onClickClose)
@@ -79,7 +96,7 @@ fun GiftCompleteScreen(
     Scaffold(
         topBar = {
             PaymentToolbar(onClickHome = onClickHome, onClickClose = onClickClose)
-        }
+        },
     ) { innerPadding ->
         Box {
             Column(
@@ -90,7 +107,10 @@ fun GiftCompleteScreen(
             ) {
                 val month = reservation?.salesEndDateTime?.month?.value ?: 0
                 val day = reservation?.salesEndDateTime?.dayOfMonth ?: 0
-                val senderText = stringResource(id = R.string.gift_sender_description, reservation?.depositorName ?: "")
+                val senderText = stringResource(
+                    id = R.string.gift_sender_description,
+                    reservation?.depositorName ?: ""
+                )
                 val dateText = stringResource(id = R.string.gift_expiration_date, month, day)
                 val buttonText = stringResource(id = R.string.gift_check)
 
@@ -156,26 +176,11 @@ fun GiftCompleteScreen(
                     ShowInformation(
                         reservation = reservation
                     )
-                }
-                Spacer(modifier = Modifier.height(88.dp))
-            }
-            reservation?.let { reservation ->
-                Column(
-                    modifier = Modifier.align(Alignment.BottomCenter)
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(16.dp)
-                            .background(
-                                brush = Brush.verticalGradient(listOf(Color.Transparent, Grey95))
-                            )
-                    )
                     SecondaryButton(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .background(Grey95)
-                            .padding(horizontal = marginHorizontal, vertical = 8.dp),
+                            .padding(top = 16.dp)
+                            .padding(vertical = 8.dp),
                         label = stringResource(R.string.show_reservation),
                     ) {
                         navigateToReservation(reservation)
@@ -372,5 +377,21 @@ private fun ShowInformation(
             showName = reservation.showName,
             showDate = reservation.showDate,
         )
+    }
+}
+
+@Composable
+@Preview
+fun GiftCompleteScreenPreview(
+) {
+    BooltiTheme {
+        Surface {
+            GiftCompleteScreen(
+                onClickClose = {},
+                onClickHome = {},
+                navigateToReservation = {},
+                reservation = dummyReservationDetail
+            )
+        }
     }
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/giftcomplete/GiftCompleteScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/giftcomplete/GiftCompleteScreen.kt
@@ -90,6 +90,7 @@ fun GiftCompleteScreen(
             ) {
                 val month = reservation?.salesEndDateTime?.month?.value ?: 0
                 val day = reservation?.salesEndDateTime?.dayOfMonth ?: 0
+                val senderText = stringResource(id = R.string.gift_sender_description, reservation?.depositorName ?: "")
                 val dateText = stringResource(id = R.string.gift_expiration_date, month, day)
                 val buttonText = stringResource(id = R.string.gift_check)
 
@@ -120,7 +121,7 @@ fun GiftCompleteScreen(
                     onClick = {
                         if (ShareClient.instance.isKakaoTalkSharingAvailable(context)) {
                             reservation?.let {
-                                sendMessage(context, it, dateText, buttonText)
+                                sendMessage(context, it, senderText, dateText, buttonText)
                             }
                         } else {
                             // TODO: 카카오톡 미설치 케이스 (아직은 고려 X)
@@ -188,6 +189,7 @@ fun GiftCompleteScreen(
 private fun sendMessage(
     context: Context,
     reservation: ReservationDetail,
+    senderText: String,
     dateText: String,
     buttonText: String
 ) {
@@ -195,7 +197,7 @@ private fun sendMessage(
         sendMessage(
             context,
             giftUuid,
-            reservation.visitorName,
+            senderText,
             reservation.giftInviteImage,
             dateText,
             buttonText
@@ -206,7 +208,7 @@ private fun sendMessage(
 fun sendMessage(
     context: Context,
     giftUuid: String,
-    receiverName: String,
+    senderText: String,
     image: String,
     dateText: String,
     buttonText: String
@@ -216,7 +218,7 @@ fun sendMessage(
 
     val defaultFeed = FeedTemplate(
         content = Content(
-            title = "To. $receiverName",
+            title = senderText,
             description = dateText,
             imageUrl = image,
             link = Link(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/Indicator.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/Indicator.kt
@@ -14,12 +14,10 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun Indicator(
-    modifier: Modifier = Modifier,
     position: Int,
     size: Int,
+    modifier: Modifier = Modifier,
 ) {
-    if (size == 1) return
-
     Row(modifier = modifier) {
         (0 until size).forEach { index ->
             val opacity = if (index == position) 1f else 0.5f

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowImagesScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowImagesScreen.kt
@@ -1,25 +1,18 @@
 package com.nexters.boolti.presentation.screen.showdetail
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -29,7 +22,6 @@ import com.nexters.boolti.presentation.component.BtCloseableAppBar
 import net.engawapg.lib.zoomable.rememberZoomState
 import net.engawapg.lib.zoomable.zoomable
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ShowImagesScreen(
     index: Int,
@@ -49,31 +41,40 @@ fun ShowImagesScreen(
     ) { innerPadding ->
         Column(
             modifier = Modifier
-                .fillMaxSize()
                 .padding(innerPadding)
-                .padding(top = 56.dp),
+                .fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.SpaceBetween,
         ) {
-            HorizontalPager(
-                modifier = Modifier,
-                state = pageState,
-                key = { it },
+            Box(
+                modifier = Modifier.weight(1f),
+                contentAlignment = Alignment.Center,
             ) {
-                AsyncImage(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .zoomable(rememberZoomState()),
-                    model = uiState.showDetail.images[it].originImage,
-                    contentDescription = null,
-                    contentScale = ContentScale.FillWidth,
-                )
+                HorizontalPager(
+                    state = pageState,
+                    key = { it },
+                ) {
+                    AsyncImage(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .zoomable(rememberZoomState()),
+                        model = uiState.showDetail.images[it].originImage,
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                    )
+                }
             }
-            Indicator(
-                modifier = Modifier.padding(bottom = 20.dp),
-                position = pageState.currentPage,
-                size = pageState.pageCount,
-            )
+
+            Box(
+                modifier = Modifier.height(47.dp), // indicator 높이가 7이라...
+                contentAlignment = Alignment.Center
+            ) {
+                if (pageState.pageCount > 1) {
+                    Indicator(
+                        position = pageState.currentPage,
+                        size = pageState.pageCount,
+                    )
+                }
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/SwipeableImage.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/SwipeableImage.kt
@@ -1,16 +1,13 @@
 package com.nexters.boolti.presentation.screen.showdetail
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -27,7 +24,6 @@ import coil.compose.AsyncImage
 import com.nexters.boolti.presentation.constants.posterRatio
 import com.nexters.boolti.presentation.theme.Grey95
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SwipeableImage(
     models: List<String>,
@@ -72,10 +68,12 @@ fun SwipeableImage(
                     )
                 )
         )
-        Indicator(
-            modifier = Modifier.padding(bottom = 14.dp),
-            position = pageState.currentPage,
-            size = models.size
-        )
+        if (models.size > 1) {
+            Indicator(
+                modifier = Modifier.padding(bottom = 14.dp),
+                position = pageState.currentPage,
+                size = models.size
+            )
+        }
     }
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -194,6 +194,7 @@
     <string name="gift_select_receiver">받는 분 선택하기</string>
     <string name="gift_selected_image">선택된 선물 이미지</string>
     <string name="gift_image">선물 편지에 포함될 이미지</string>
+    <string name="gift_sender_description">%s님이 보낸 선물이 도착했어요.</string>
     <string name="gift_expiration_date">%d월 %d일까지 불티앱에서 선물을 등록해주세요.</string>
     <string name="gift_check">선물 확인하기</string>
     <string name="gift_resend_message">선물 링크 다시 보내기</string>


### PR DESCRIPTION
## Issue
- close #308 

## 작업 내용
- 제곧내
- 참고로 브랜치 넘버링 잘못함 ㅋㅋㅋㅋ

https://github.com/user-attachments/assets/8a404f70-8dd4-4d80-99c7-297c0bba298d

## 디자인 QA 추가
- 카드 변경 시 이미지 깜빡임 현상 -> 이미지 비율 고정, 로딩 시 테두리 제거, cross fade 적용
- 선물 결제 완료 페이지에서 "결제 내역 보기" 버튼 위치 고정 해제
- 선물 카카오톡 전송 메시지 변경