### PR TITLE
Boolti-319 feat: 토스페이먼츠 상품명 수정

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/GiftScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/gift/GiftScreen.kt
@@ -107,7 +107,7 @@ fun GiftScreen(
                                 clientKey = BuildConfig.TOSS_CLIENT_KEY,
                                 customerKey = "user-${event.userId}",
                                 orderId = event.orderId,
-                                orderName = "${uiState.showName} ${uiState.ticketName}",
+                                orderName = "${viewModel.showId}/${uiState.ticketName}/${uiState.ticketCount}/Android",
                                 currency = Currency.KRW.name,
                                 countryCode = "KR",
                                 showId = viewModel.showId,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingScreen.kt
@@ -94,7 +94,6 @@ import com.nexters.boolti.tosspayments.TossPaymentWidgetActivity
 import com.nexters.boolti.tosspayments.TossPaymentWidgetActivity.Companion.RESULT_FAIL
 import com.nexters.boolti.tosspayments.TossPaymentWidgetActivity.Companion.RESULT_SOLD_OUT
 import com.nexters.boolti.tosspayments.TossPaymentWidgetActivity.Companion.RESULT_SUCCESS
-import com.nexters.boolti.tosspayments.extension.convertQuotes
 import java.time.LocalDateTime
 
 @Composable
@@ -146,7 +145,7 @@ fun TicketingScreen(
                             clientKey = BuildConfig.TOSS_CLIENT_KEY,
                             customerKey = "user-${it.userId}",
                             orderId = it.orderId,
-                            orderName = "${viewModel.showId}/${uiState.ticketName}/${uiState.ticketCount}/Android".convertQuotes(),
+                            orderName = "${viewModel.showId}/${uiState.ticketName}/${uiState.ticketCount}/Android",
                             currency = Currency.KRW.name,
                             countryCode = "KR",
                             showId = viewModel.showId,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -95,6 +94,7 @@ import com.nexters.boolti.tosspayments.TossPaymentWidgetActivity
 import com.nexters.boolti.tosspayments.TossPaymentWidgetActivity.Companion.RESULT_FAIL
 import com.nexters.boolti.tosspayments.TossPaymentWidgetActivity.Companion.RESULT_SOLD_OUT
 import com.nexters.boolti.tosspayments.TossPaymentWidgetActivity.Companion.RESULT_SUCCESS
+import com.nexters.boolti.tosspayments.extension.convertQuotes
 import java.time.LocalDateTime
 
 @Composable
@@ -146,7 +146,7 @@ fun TicketingScreen(
                             clientKey = BuildConfig.TOSS_CLIENT_KEY,
                             customerKey = "user-${it.userId}",
                             orderId = it.orderId,
-                            orderName = "${uiState.showName} ${uiState.ticketName}",
+                            orderName = "${viewModel.showId}/${uiState.ticketName}/${uiState.ticketCount}/Android".convertQuotes(),
                             currency = Currency.KRW.name,
                             countryCode = "KR",
                             showId = viewModel.showId,

--- a/tosspayments/src/main/java/com/nexters/boolti/tosspayments/TossPaymentWidgetActivity.kt
+++ b/tosspayments/src/main/java/com/nexters/boolti/tosspayments/TossPaymentWidgetActivity.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.nexters.boolti.tosspayments.databinding.ActivityTossPaymentWidgetBinding
-import com.nexters.boolti.tosspayments.extension.percentEncode
+import com.nexters.boolti.tosspayments.extension.convertQuotes
 import com.nexters.boolti.tosspayments.extension.toCurrency
 import com.tosspayments.paymentsdk.PaymentWidget
 import com.tosspayments.paymentsdk.model.AgreementStatus
@@ -254,20 +254,22 @@ class TossPaymentWidgetActivity : AppCompatActivity() {
             variantKey: String? = null,
             redirectUrl: String? = null,
         ): Intent {
-            return Intent(context, TossPaymentWidgetActivity::class.java)
+            return getCommonIntent(
+                context = context,
+                amount = amount,
+                clientKey = clientKey,
+                customerKey = customerKey,
+                orderId = orderId,
+                orderName = orderName,
+                currency = currency,
+                countryCode = countryCode,
+                showId = showId,
+                salesTicketTypeId = salesTicketTypeId,
+                ticketCount = ticketCount,
+            )
                 .putExtra(EXTRA_KEY_ORDER_TYPE, OrderType.TICKETING)
-                .putExtra(EXTRA_KEY_AMOUNT, amount)
-                .putExtra(EXTRA_KEY_CLIENT_KEY, clientKey)
-                .putExtra(EXTRA_KEY_CUSTOMER_KEY, customerKey)
-                .putExtra(EXTRA_KEY_ORDER_ID, orderId)
-                .putExtra(EXTRA_KEY_ORDER_NAME, orderName.percentEncode())
-                .putExtra(EXTRA_KEY_CURRENCY, currency.toCurrency())
-                .putExtra(EXTRA_KEY_COUNTRY_CODE, countryCode)
                 .putExtra(EXTRA_KEY_VARIANT_KEY, variantKey)
                 .putExtra(EXTRA_KEY_REDIRECT_URL, redirectUrl)
-                .putExtra(EXTRA_KEY_SHOW_ID, showId)
-                .putExtra(EXTRA_KEY_SALES_TICKET_ID, salesTicketTypeId)
-                .putExtra(EXTRA_KEY_TICKET_COUNT, ticketCount)
                 .putExtra(EXTRA_KEY_RESERVATION_NAME, reservationName)
                 .putExtra(EXTRA_KEY_RESERVATION_PHONE_NUMBER, reservationPhoneNumber)
                 .putExtra(EXTRA_KEY_DEPOSITOR_NAME, depositorName)
@@ -293,18 +295,20 @@ class TossPaymentWidgetActivity : AppCompatActivity() {
             message: String,
             imageId: String,
         ): Intent {
-            return Intent(context, TossPaymentWidgetActivity::class.java)
+            return getCommonIntent(
+                context = context,
+                amount = amount,
+                clientKey = clientKey,
+                customerKey = customerKey,
+                orderId = orderId,
+                orderName = orderName,
+                currency = currency,
+                countryCode = countryCode,
+                showId = showId,
+                salesTicketTypeId = salesTicketTypeId,
+                ticketCount = ticketCount,
+            )
                 .putExtra(EXTRA_KEY_ORDER_TYPE, OrderType.GIFT)
-                .putExtra(EXTRA_KEY_AMOUNT, amount)
-                .putExtra(EXTRA_KEY_CLIENT_KEY, clientKey)
-                .putExtra(EXTRA_KEY_CUSTOMER_KEY, customerKey)
-                .putExtra(EXTRA_KEY_ORDER_ID, orderId)
-                .putExtra(EXTRA_KEY_ORDER_NAME, orderName.percentEncode())
-                .putExtra(EXTRA_KEY_CURRENCY, currency.toCurrency())
-                .putExtra(EXTRA_KEY_COUNTRY_CODE, countryCode)
-                .putExtra(EXTRA_KEY_SHOW_ID, showId)
-                .putExtra(EXTRA_KEY_SALES_TICKET_ID, salesTicketTypeId)
-                .putExtra(EXTRA_KEY_TICKET_COUNT, ticketCount)
                 .putExtra(EXTRA_KEY_SENDER_NAME, senderName)
                 .putExtra(EXTRA_KEY_SENDER_PHONE_NUMBER, senderContact)
                 .putExtra(EXTRA_KEY_RECEIVER_NAME, receiverName)
@@ -312,5 +316,29 @@ class TossPaymentWidgetActivity : AppCompatActivity() {
                 .putExtra(EXTRA_KEY_MESSAGE, message)
                 .putExtra(EXTRA_KEY_IMAGE_ID, imageId)
         }
+
+        private fun getCommonIntent(
+            context: Context,
+            amount: Number,
+            clientKey: String,
+            customerKey: String,
+            orderId: String,
+            orderName: String,
+            currency: String,
+            countryCode: String,
+            showId: String,
+            salesTicketTypeId: String,
+            ticketCount: Int,
+        ): Intent = Intent(context, TossPaymentWidgetActivity::class.java)
+            .putExtra(EXTRA_KEY_AMOUNT, amount)
+            .putExtra(EXTRA_KEY_CLIENT_KEY, clientKey)
+            .putExtra(EXTRA_KEY_CUSTOMER_KEY, customerKey)
+            .putExtra(EXTRA_KEY_ORDER_ID, orderId)
+            .putExtra(EXTRA_KEY_ORDER_NAME, orderName.convertQuotes())
+            .putExtra(EXTRA_KEY_CURRENCY, currency.toCurrency())
+            .putExtra(EXTRA_KEY_COUNTRY_CODE, countryCode)
+            .putExtra(EXTRA_KEY_SHOW_ID, showId)
+            .putExtra(EXTRA_KEY_SALES_TICKET_ID, salesTicketTypeId)
+            .putExtra(EXTRA_KEY_TICKET_COUNT, ticketCount)
     }
 }

--- a/tosspayments/src/main/java/com/nexters/boolti/tosspayments/extension/String.kt
+++ b/tosspayments/src/main/java/com/nexters/boolti/tosspayments/extension/String.kt
@@ -1,5 +1,37 @@
 package com.nexters.boolti.tosspayments.extension
 
+/**
+ * ## 따옴표 변환
+ *
+ * 큰 따옴표(")를 열리는 큰 따옴표(“)와 닫히는 큰 따옴표(”)로 변환하거나
+ * 작은 따옴표(')를 열리는 작은 따옴표(‘)와 닫히는 작은 따옴표(’)로 변환
+ *
+ * 토스페이먼츠에서 orderName에 따옴표가 들어간 경우 결제 렌더링이 안 되는 문제 해결을 위해 다른 문자로 대체하기 위해 사용함
+ *
+ * @see [TossPaymentWidgetActivity.getCommonIntent]
+ * @return 따옴표가 변환된 문자열을 반환
+ */
+fun String.convertQuotes(): String = StringBuilder().apply {
+    var isDoubleQuoteOpen = true
+    var isSingleQuoteOpen = true
+
+    this@convertQuotes.forEach { c ->
+        when (c) {
+            '"' -> {
+                append(if (isDoubleQuoteOpen) "“" else "”")
+                isDoubleQuoteOpen = !isDoubleQuoteOpen
+            }
+
+            '\'' -> {
+                append(if (isSingleQuoteOpen) "‘" else "’")
+                isSingleQuoteOpen = !isSingleQuoteOpen
+            }
+
+            else -> append(c)
+        }
+    }
+}.toString()
+
 private val encodingMap = mapOf(
     ':' to "%3A",
     '/' to "%2F",


### PR DESCRIPTION
## Issue
- close #319 

## 작업 내용

- 토스 페이먼츠의 orderName 형식 변경
- 문자 대체 로직 변경
  - 기존 특수문자들을 변환하는 퍼센트 인코딩 방식에서 따옴표만 다른 문자로 변경하도록 변경
  - 여러 테스트 결과 따옴표에서만 결제 페이지 렌더링이 안 되는 문제 발견
- 결제 공통 인텐트 키 값 처리

<img width="80%" alt="image" src="https://github.com/user-attachments/assets/1ad709b7-5425-4eae-b96f-6139b116bf36">

_따옴표가 순서에 맞게 잘 변환되어 페이먼츠 콘솔에 찍히는 모습_