### PR TITLE
Revert "fix : [딥 링크] 이후 뒤로 가기시 홈이 아닌 티켓 탭이 나오는 현상 수정"

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/home/HomeScreen.kt
@@ -1,6 +1,5 @@
 package com.nexters.boolti.presentation.screen.home
 
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
@@ -77,8 +76,6 @@ fun HomeScreen(
     val giftRegistrationMessage = stringResource(id = R.string.gift_successfully_registered)
 
     var dialog: GiftStatus? by rememberSaveable { mutableStateOf(null) }
-
-    removeInvalidDeepLink(LocalContext.current)
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -206,19 +203,6 @@ fun HomeScreen(
                 viewModel.cancelGift()
             }
         )
-    }
-}
-
-/**
- * issue #209를 해결하기 위한 메서드.
- * 처리하지 말아야 할 deep link가 부적절한 destination과 match되는 것을 방지하기 위함.
- */
-private fun removeInvalidDeepLink(context: Context) {
-    runCatching {
-        val intent = context.requireActivity().intent
-        if (intent.action == null) return
-        val deepLink = intent.action!!
-        if (!deepLink.contains("home")) intent.setAction(null)
     }
 }
 


### PR DESCRIPTION
Reverts Nexters/Boolti#252
- home에서 처리하지만 home이 포함되지 않는 딥 링크가 존재해 선물 받기 기능이 동작하지 않는 현상이 있음