### PR TITLE
홈 공연등록 로그인 안 된 유저 방어

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/Main.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/Main.kt
@@ -22,8 +22,8 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.navigation
 import androidx.navigation.navDeepLink
+import com.nexters.boolti.domain.model.User
 import com.nexters.boolti.presentation.component.ToastSnackbarHost
-import com.nexters.boolti.presentation.screen.reservationdetail.reservationDetailScreen
 import com.nexters.boolti.presentation.screen.accountsetting.accountSettingScreen
 import com.nexters.boolti.presentation.screen.business.businessScreen
 import com.nexters.boolti.presentation.screen.gift.giftScreen
@@ -45,6 +45,7 @@ import com.nexters.boolti.presentation.screen.qr.hostedShowScreen
 import com.nexters.boolti.presentation.screen.qr.qrFullScreen
 import com.nexters.boolti.presentation.screen.refund.refundScreen
 import com.nexters.boolti.presentation.screen.report.reportScreen
+import com.nexters.boolti.presentation.screen.reservationdetail.reservationDetailScreen
 import com.nexters.boolti.presentation.screen.reservations.reservationsScreen
 import com.nexters.boolti.presentation.screen.showdetail.showDetailScreen
 import com.nexters.boolti.presentation.screen.showdetail.showImagesScreen
@@ -64,9 +65,14 @@ val LocalNavController = compositionLocalOf<NavHostController> {
     error("No NavController provided")
 }
 
+val LocalUser = compositionLocalOf<User?> { null }
+
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun Main(onClickQrScan: (showId: String, showName: String) -> Unit) {
+fun Main(
+    user: User? = null,
+    onClickQrScan: (showId: String, showName: String) -> Unit,
+) {
     val modifier = Modifier.fillMaxSize()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -87,6 +93,7 @@ fun Main(onClickQrScan: (showId: String, showName: String) -> Unit) {
                     scope,
                 ),
                 LocalNavController provides rootNavController,
+                LocalUser provides user,
             ) {
                 MainNavigation(
                     modifier = modifier,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/MainActivity.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/MainActivity.kt
@@ -13,9 +13,12 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.firebase.Firebase
 import com.google.firebase.messaging.messaging
+import com.nexters.boolti.domain.repository.AuthRepository
 import com.nexters.boolti.presentation.BuildConfig
 import com.nexters.boolti.presentation.QrScanActivity
 import com.nexters.boolti.presentation.R
@@ -24,21 +27,28 @@ import com.nexters.boolti.presentation.extension.startActivity
 import com.nexters.boolti.presentation.theme.BooltiTheme
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @Inject
+    lateinit var authRepository: AuthRepository
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
         )
         setContent {
+            val user by authRepository.cachedUser.collectAsStateWithLifecycle(null)
+
             BooltiTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
+                    color = MaterialTheme.colorScheme.background,
                 ) {
                     Main(
+                        user = user,
                         onClickQrScan = { showId, showName ->
                             startActivity<QrScanActivity> {
                                 putExtra("showId", showId)

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/home/HomeNavigation.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/home/HomeNavigation.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.nexters.boolti.presentation.screen.LocalNavController
+import com.nexters.boolti.presentation.screen.LocalUser
 import com.nexters.boolti.presentation.screen.MainDestination
 import com.nexters.boolti.presentation.screen.navigation.MainRoute
 import com.nexters.boolti.presentation.screen.navigation.ShowRoute
@@ -14,6 +15,8 @@ fun NavGraphBuilder.homeScreen(
 ) {
     composable<MainRoute.Home> {
         val navController = LocalNavController.current
+        val user = LocalUser.current
+
         HomeScreen(
             modifier = modifier,
             navigateToShowDetail = { navController.navigate(ShowRoute.ShowRoot(showId = it)) },
@@ -23,7 +26,12 @@ fun NavGraphBuilder.homeScreen(
             navigateToReservations = { navController.navigate(MainRoute.Reservations) },
             navigateToProfile = { navController.navigate(MainRoute.Profile()) },
             navigateToBusiness = { navController.navigate(MainRoute.Business) },
-            navigateToShowRegistration = { navController.navigate(MainDestination.ShowRegistration.route) },
+            navigateToShowRegistration = {
+                if (user != null)
+                    navController.navigate(MainDestination.ShowRegistration.route)
+                else
+                    navController.navigate(MainRoute.Login)
+            },
             navigateToLogin = { navController.navigate(MainRoute.Login) },
         )
     }


### PR DESCRIPTION
## Issue
- close #377 

## 작업 내용

- LocalProvider 로 유저 정보 접근할 수 있도록 추가
  - 유저 상태에 대해서 앱 전역적으로 상태를 확인할 니즈가 있다고 판단함
- `navigateToShowRegistration` 에서 로그인 상태를 체크함으로써 홈에서 로그인 상태를 보지 않고 공연 등록 화면으로 넘어가는 버그를 수정하고, 앞으로 생길 수 있는 공연 등록에 대해서도 로그인 상태를 체크할 수 있도록 대비함


https://github.com/user-attachments/assets/aefb0f00-1e0a-4b7b-9a8b-7854377625f3

