### PR TITLE
chore: 브라우저에서 도메인을 검증할 수 있도록 설정을 추가하고, 불필요한 딥링크가 생기지 않도록 카카오 스킴과 분리했어요.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
             android:windowSoftInputMode="adjustPan"
             android:theme="@style/Theme.Boolti">
 
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -46,6 +46,15 @@
                 <data android:scheme="https" />
                 <data android:host="app.boolti.in" />
                 <data android:host="preview.boolti.in" />
+                <data android:host="dev.preview.boolti.in" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
                 <data
                     android:host="kakaolink"
                     android:scheme="kakao${KAKAO_APP_KEY}" />


### PR DESCRIPTION
## Issue
- close #396 

## 작업 내용
- 기존에 카카오 스킴과 동거하던 문제를 수정했어요.
- autoVerify를 추가하여 브라우저에서 도메인을 검증할 수 있도록 설정을 추가했어요.

https://github.com/user-attachments/assets/e1728824-2c6b-4d72-98aa-a2a0605a78ed

