### PR TITLE
Feature/boolti 414 QA 반영 및 페이징 API 응답 시그니처 변경 대응

### DIFF
--- a/data/src/main/java/com/nexters/boolti/data/datasource/SearchDataSource.kt
+++ b/data/src/main/java/com/nexters/boolti/data/datasource/SearchDataSource.kt
@@ -1,14 +1,12 @@
 package com.nexters.boolti.data.datasource
 
 import com.nexters.boolti.data.network.api.SearchService
-import com.nexters.boolti.data.network.response.MemberResponse
-import com.nexters.boolti.data.network.response.ShowResponse
 import com.nexters.boolti.data.network.response.toNewShowsAndRisingKeywords
-import com.nexters.boolti.data.util.getPagingData
-import com.nexters.boolti.data.util.toPagingData
+import com.nexters.boolti.data.network.response.toPagingData
 import com.nexters.boolti.domain.model.NewShowsAndRisingKeywords
 import com.nexters.boolti.domain.model.PagingData
 import com.nexters.boolti.domain.model.Show
+import com.nexters.boolti.domain.model.User
 import com.nexters.boolti.domain.model.map
 import javax.inject.Inject
 
@@ -23,7 +21,7 @@ internal class SearchDataSource @Inject constructor(
         size: Int,
     ): PagingData<Show> {
         return searchService.requestShows(keyword, page, size)
-            .toPagingData(ShowResponse.serializer())
+            .toPagingData()
             .map { it.toDomain() }
     }
 
@@ -31,7 +29,9 @@ internal class SearchDataSource @Inject constructor(
         keyword: String,
         page: Int,
         size: Int,
-    ): PagingData<MemberResponse> = getPagingData { searchService.requestProfiles(keyword, page, size) }
+    ): PagingData<User.Others> = searchService.requestProfiles(keyword, page, size)
+        .toPagingData()
+        .map { it.toDomain() }
 
     suspend fun getAutoCompleteKeywords(
         keyword: String,

--- a/data/src/main/java/com/nexters/boolti/data/network/api/SearchService.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/api/SearchService.kt
@@ -1,7 +1,9 @@
 package com.nexters.boolti.data.network.api
 
+import com.nexters.boolti.data.network.response.MemberResponse
+import com.nexters.boolti.data.network.response.PagingResponse
 import com.nexters.boolti.data.network.response.SearchOverviewResponse
-import kotlinx.serialization.json.JsonObject
+import com.nexters.boolti.data.network.response.ShowResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -17,7 +19,7 @@ internal interface SearchService {
         page: Int,
         @Query("size")
         size: Int,
-    ): JsonObject
+    ): PagingResponse<ShowResponse>
 
     @GET("/app/papi/v1/shows/artists")
     suspend fun requestProfiles(
@@ -27,7 +29,7 @@ internal interface SearchService {
         page: Int,
         @Query("size")
         size: Int,
-    ): JsonObject
+    ): PagingResponse<MemberResponse>
 
     @GET("/app/papi/v1/shows/autocomplete")
     suspend fun requestAutoCompleteKeywords(

--- a/data/src/main/java/com/nexters/boolti/data/network/response/PagingResponse.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/response/PagingResponse.kt
@@ -1,0 +1,30 @@
+package com.nexters.boolti.data.network.response
+
+import com.nexters.boolti.domain.model.PagingData
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PagingResponse<T>(
+    @SerialName("items")
+    val items: List<T>,
+    @SerialName("currentPage")
+    val currentPage: Int,
+    @SerialName("pageSize")
+    val pageSize: Int,
+    @SerialName("totalElements")
+    val totalElements: Long,
+    @SerialName("totalPages")
+    val totalPages: Int,
+    @SerialName("hasNext")
+    val hasNext: Boolean,
+)
+
+fun <T> PagingResponse<T>.toPagingData(): PagingData<T> = PagingData(
+    items = items,
+    currentPage = currentPage,
+    pageSize = pageSize,
+    totalElements = totalElements,
+    totalPages = totalPages,
+    hasNext = hasNext,
+)

--- a/data/src/main/java/com/nexters/boolti/data/repository/SearchRepositoryImpl.kt
+++ b/data/src/main/java/com/nexters/boolti/data/repository/SearchRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.nexters.boolti.domain.model.NewShowsAndRisingKeywords
 import com.nexters.boolti.domain.model.PagingData
 import com.nexters.boolti.domain.model.Show
 import com.nexters.boolti.domain.model.User
-import com.nexters.boolti.domain.model.map
 import com.nexters.boolti.domain.repository.SearchRepository
 import com.nexters.boolti.domain.util.suspendRunCatching
 import javax.inject.Inject
@@ -32,6 +31,6 @@ internal class SearchRepositoryImpl @Inject constructor(
         keyword: String,
         page: Int
     ): Result<PagingData<User.Others>> = suspendRunCatching {
-        searchDataSource.getProfiles(keyword, page, 10).map { it.toDomain() }
+        searchDataSource.getProfiles(keyword, page, 10)
     }
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/BtChip.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/BtChip.kt
@@ -28,6 +28,7 @@ import com.nexters.boolti.presentation.R
 import com.nexters.boolti.presentation.theme.BooltiTheme
 import com.nexters.boolti.presentation.theme.Grey15
 import com.nexters.boolti.presentation.theme.Grey50
+import com.nexters.boolti.presentation.theme.Grey85
 
 @Composable
 fun BtChip(
@@ -41,6 +42,7 @@ fun BtChip(
         border = null,
         onClick = onClick,
         shape = RoundedCornerShape(100.dp),
+        color = Grey85,
     ) {
         Row(
             modifier = Modifier

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailIntent.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailIntent.kt
@@ -1,8 +1,6 @@
 package com.nexters.boolti.presentation.screen.search.detail
 
 sealed interface SearchDetailIntent {
-    data class KeywordChanged(val keyword: String) : SearchDetailIntent
-    data class Search(val keyword: String) : SearchDetailIntent
     data class ChangeTabIndex(val index: Int) : SearchDetailIntent
 
     data object OnShowsPageReached : SearchDetailIntent

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailNavigation.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailNavigation.kt
@@ -30,6 +30,9 @@ fun NavGraphBuilder.searchDetailNavigation(
         }
 
         SearchDetailScreen(
+            navigateToRecentSearch = {
+                navController.navigate(SearchRoute.RecentSearch)
+            },
             navigateToShowDetail = { showId ->
                 navController.navigate(ShowRoute.ShowRoot(showId))
             },
@@ -37,13 +40,7 @@ fun NavGraphBuilder.searchDetailNavigation(
                 navController.navigate(MainRoute.Profile(userCode))
             },
             navigateUp = {
-                navController.popBackStack()
-                navController.navigate(SearchRoute.RecentSearch) {
-                    popUpTo<SearchRoute.RecentSearch> {
-                        inclusive = false
-                    }
-                    launchSingleTop = true
-                }
+                navController.popBackStack(MainRoute.Home, false)
             },
             modifier = modifier,
         )

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailScreen.kt
@@ -69,6 +69,7 @@ import com.nexters.boolti.presentation.theme.marginHorizontal
 
 @Composable
 fun SearchDetailScreen(
+    navigateToRecentSearch: () -> Unit,
     navigateToShowDetail: (id: String) -> Unit,
     navigateToProfile: (userCode: UserCode) -> Unit,
     navigateUp: () -> Unit,
@@ -87,9 +88,7 @@ fun SearchDetailScreen(
 
     SearchDetailScreen(
         keyword = uiState.keyword,
-        onChangeKeyword = {
-            viewModel.onIntent(SearchDetailIntent.KeywordChanged(it))
-        },
+        onClickSearchBar = navigateToRecentSearch,
         searchedKeyword = uiState.searchedKeyword,
         loading = uiState.loading,
         shows = uiState.shows,
@@ -104,9 +103,6 @@ fun SearchDetailScreen(
         },
         onClickShow = navigateToShowDetail,
         onClickProfile = navigateToProfile,
-        search = {
-            viewModel.onIntent(SearchDetailIntent.Search(it))
-        },
         onShowsPageReached = {
             viewModel.onIntent(SearchDetailIntent.OnShowsPageReached)
         },
@@ -121,7 +117,7 @@ fun SearchDetailScreen(
 @Composable
 private fun SearchDetailScreen(
     keyword: String,
-    onChangeKeyword: (String) -> Unit,
+    onClickSearchBar: () -> Unit,
     searchedKeyword: String,
     loading: Boolean,
     shows: List<Show>,
@@ -134,7 +130,6 @@ private fun SearchDetailScreen(
     onChangeIndex: (Int) -> Unit,
     onClickShow: (id: String) -> Unit,
     onClickProfile: (userCode: UserCode) -> Unit,
-    search: (keyword: String) -> Unit,
     onShowsPageReached: () -> Unit,
     onProfilesPageReached: () -> Unit,
     navigateUp: () -> Unit,
@@ -157,11 +152,17 @@ private fun SearchDetailScreen(
             BtSearchBar(
                 modifier = Modifier
                     .padding(vertical = 12.dp)
-                    .padding(horizontal = marginHorizontal),
+                    .padding(horizontal = marginHorizontal)
+                    .clickable(
+                        interactionSource = null,
+                        indication = null,
+                        onClick = onClickSearchBar,
+                    ),
                 keyword = keyword,
+                enabled = false,
                 hint = stringResource(R.string.search_search_hint),
-                onKeywordChanged = onChangeKeyword,
-                search = { search(keyword) },
+                onKeywordChanged = {},
+                search = {},
             )
 
             if (!loading && shows.isEmpty() && profiles.isEmpty()) {

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -351,6 +352,7 @@ private fun TabRow(
         HorizontalDivider(modifier = Modifier.fillMaxWidth(), thickness = 1.dp, color = Grey85)
     },
     indicatorColor: Color = Grey15,
+    indicatorHeight: Dp = 2.dp,
     tabLabelStyle: TextStyle = MaterialTheme.typography.titleMedium,
     selectedContentColor: Color = Grey05,
     unselectedContentColor: Color = Grey70,
@@ -397,17 +399,14 @@ private fun TabRow(
                             onDraw = {
                                 drawContent()
                                 if (index == selectedIndex) {
-                                    val y = size.height + verticalPadding.roundToPx() - 1.dp.roundToPx()
-                                    drawLine(
+                                    val y = size.height + verticalPadding.roundToPx() - indicatorHeight.roundToPx()
+                                    drawRect(
                                         color = indicatorColor,
-                                        start = Offset(
+                                        topLeft = Offset(
                                             x = 0f,
                                             y = y,
                                         ),
-                                        end = Offset(
-                                            x = size.width,
-                                            y = y,
-                                        ),
+                                        size = Size(width = size.width, height = indicatorHeight.toPx()),
                                     )
                                 }
                             },
@@ -448,6 +447,7 @@ private fun AllTab(
                             .fillMaxWidth()
                             .padding(horizontal = marginHorizontal),
                         showNameStyle = MaterialTheme.typography.titleLarge,
+                        showDateStyle = MaterialTheme.typography.bodySmall.copy(color = Grey50),
                         backgroundColor = MaterialTheme.colorScheme.background,
                         contentPadding = PaddingValues(0.dp),
                         onClick = { onClickShow(show.id) },
@@ -524,7 +524,7 @@ private fun AllTabSectionTitle(
     ) {
         Text(
             text = title,
-            style = MaterialTheme.typography.titleMedium,
+            style = MaterialTheme.typography.titleLarge,
             color = Grey05,
         )
         onClickAll?.let {

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailViewModel.kt
@@ -58,8 +58,6 @@ class SearchDetailViewModel @Inject constructor(
     fun onIntent(intent: SearchDetailIntent) {
         when (intent) {
             is SearchDetailIntent.ChangeTabIndex -> changeTabIndex(intent.index)
-            is SearchDetailIntent.KeywordChanged -> onKeywordChanged(intent.keyword)
-            is SearchDetailIntent.Search -> search(intent.keyword)
             is SearchDetailIntent.OnProfilesPageReached -> loadNextProfilesPage()
             is SearchDetailIntent.OnShowsPageReached -> loadNextShowsPage()
         }
@@ -107,10 +105,6 @@ class SearchDetailViewModel @Inject constructor(
 
     private fun changeTabIndex(index: Int) {
         _uiState.update { it.copy(tabIndex = index.takeIf { i -> i < 3 } ?: 0) }
-    }
-
-    private fun onKeywordChanged(keyword: String) {
-        _uiState.update { it.copy(keyword = keyword) }
     }
 
     private fun loadNextShowsPage() {


### PR DESCRIPTION
## Issue
- close #414

## 작업 내용

- 디자인 QA
- 탐색 관련 화면 이동 변경
  - 기존: 검색 결과 화면에서 다시 검색 가능
  - 변경: 검색 결과 화면에서 검색바 터치하면 검색창으로 이동
    - 검색창에서 백버튼 누르면 백스택에 있던 결과 화면 표시
    - 결과화면에서 백버튼 누르면 검색 탭까지 pop
- 페이징 API 응답 시그니처 변경
  - 기존: 통일되지 않은 필드 명
  - 변경: items 로 통일

<img src="" width="300" />
