### PR TITLE
검색결과 화면 빈 결과시 네비게이션 수정

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailScreen.kt
@@ -88,7 +88,7 @@ fun SearchDetailScreen(
 
     SearchDetailScreen(
         keyword = uiState.keyword,
-        onClickSearchBar = navigateToRecentSearch,
+        navigateToRecentSearch = navigateToRecentSearch,
         searchedKeyword = uiState.searchedKeyword,
         loading = uiState.loading,
         shows = uiState.shows,
@@ -117,7 +117,7 @@ fun SearchDetailScreen(
 @Composable
 private fun SearchDetailScreen(
     keyword: String,
-    onClickSearchBar: () -> Unit,
+    navigateToRecentSearch: () -> Unit,
     searchedKeyword: String,
     loading: Boolean,
     shows: List<Show>,
@@ -156,7 +156,7 @@ private fun SearchDetailScreen(
                     .clickable(
                         interactionSource = null,
                         indication = null,
-                        onClick = onClickSearchBar,
+                        onClick = navigateToRecentSearch,
                     ),
                 keyword = keyword,
                 enabled = false,
@@ -168,7 +168,7 @@ private fun SearchDetailScreen(
             if (!loading && shows.isEmpty() && profiles.isEmpty()) {
                 EmptyContents(
                     keyword = searchedKeyword,
-                    onClickResetKeyword = navigateUp,
+                    onClickResetKeyword = navigateToRecentSearch,
                     content = stringResource(R.string.search_no_result),
                 )
             } else if (!loading) {


### PR DESCRIPTION
- onClickSearchBar → navigateToRecentSearch 파라미터 이름 변경
- EmptyContents의 onClickResetKeyword가 navigateToRecentSearch 호출하도록 수정

## Issue
- close #이슈 번호

## 작업 내용


<img src="" width="300" />
