### PR TITLE
feat: SearchDetail에서 RecentSearch로 이동 시 검색어 유지

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/BtSearchBar.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/BtSearchBar.kt
@@ -22,7 +22,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,6 +33,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.nexters.boolti.presentation.R
@@ -39,11 +42,44 @@ import com.nexters.boolti.presentation.theme.Grey60
 import com.nexters.boolti.presentation.theme.Grey70
 import com.nexters.boolti.presentation.theme.Grey85
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BtSearchBar(
     keyword: String,
     onKeywordChanged: (keyword: String) -> Unit,
+    hint: String,
+    search: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    showClearButtonOnFocus: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    var textFieldValue by remember { mutableStateOf(TextFieldValue(keyword)) }
+
+    // keyword가 외부에서 변경되면 textFieldValue도 업데이트
+    if (textFieldValue.text != keyword) {
+        textFieldValue = TextFieldValue(keyword)
+    }
+
+    BtSearchBar(
+        value = textFieldValue,
+        onValueChange = { newValue ->
+            textFieldValue = newValue
+            onKeywordChanged(newValue.text)
+        },
+        hint = hint,
+        search = search,
+        modifier = modifier,
+        enabled = enabled,
+        showClearButtonOnFocus = showClearButtonOnFocus,
+        interactionSource = interactionSource,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BtSearchBar(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
     hint: String,
     search: () -> Unit,
     modifier: Modifier = Modifier,
@@ -64,15 +100,15 @@ fun BtSearchBar(
         modifier = modifier
             .fillMaxWidth()
             .height(48.dp),
-        value = keyword,
+        value = value,
         enabled = enabled,
         singleLine = true,
-        onValueChange = onKeywordChanged,
+        onValueChange = onValueChange,
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
         keyboardActions = KeyboardActions(onSearch = { search() }),
         decorationBox = { innerTextField ->
             OutlinedTextFieldDefaults.DecorationBox(
-                value = keyword,
+                value = value.text,
                 innerTextField = innerTextField,
                 enabled = true,
                 singleLine = true,
@@ -87,9 +123,9 @@ fun BtSearchBar(
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        if (showClearButtonOnFocus && keyword.isNotEmpty() && focused) {
+                        if (showClearButtonOnFocus && value.text.isNotEmpty() && focused) {
                             BTTextFieldDefaults.ClearButton(
-                                onClick = { onKeywordChanged("") },
+                                onClick = { onValueChange(TextFieldValue()) },
                             )
 
                             Spacer(Modifier.size(4.dp))

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/home/HomeNavigation.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/home/HomeNavigation.kt
@@ -30,7 +30,7 @@ fun NavGraphBuilder.homeScreen(
                     )
                 )
             },
-            navigateToRecentSearch = { navController.navigate(SearchRoute.RecentSearch) },
+            navigateToRecentSearch = { navController.navigate(SearchRoute.RecentSearch()) },
             navigateToSearchDetail = { navController.navigate(SearchRoute.SearchDetail(keyword = it)) },
             navigateToTicketDetail = { navController.navigate(TicketRoute.TicketRoot(ticketId = it)) },
             navigateToQrScan = { navController.navigate(MainRoute.HostedShows) },

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/navigation/SearchRoute.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/navigation/SearchRoute.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 sealed interface SearchRoute {
     @Serializable
-    data object RecentSearch : SearchRoute
+    data class RecentSearch(val keyword: String = "") : SearchRoute
 
     @Serializable
     data class SearchDetail(val keyword: String) : SearchRoute

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailNavigation.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailNavigation.kt
@@ -19,7 +19,7 @@ fun NavGraphBuilder.searchDetailNavigation(
 
         val navigateUp: () -> Unit = {
             navController.popBackStack()
-            navController.navigate(SearchRoute.RecentSearch) {
+            navController.navigate(SearchRoute.RecentSearch()) {
                 popUpTo<SearchRoute.RecentSearch> {
                     inclusive = false
                 }
@@ -32,8 +32,8 @@ fun NavGraphBuilder.searchDetailNavigation(
         }
 
         SearchDetailScreen(
-            navigateToRecentSearch = {
-                navController.navigate(SearchRoute.RecentSearch)
+            navigateToRecentSearch = { keyword ->
+                navController.navigate(SearchRoute.RecentSearch(keyword))
             },
             navigateToShowDetail = { showId ->
                 navController.navigate(ShowRoute.ShowRoot(showId, source = Screen.SearchDetail.value))

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/detail/SearchDetailScreen.kt
@@ -78,7 +78,7 @@ import com.nexters.boolti.presentation.theme.marginHorizontal
 
 @Composable
 fun SearchDetailScreen(
-    navigateToRecentSearch: () -> Unit,
+    navigateToRecentSearch: (keyword: String) -> Unit,
     navigateToShowDetail: (id: String) -> Unit,
     navigateToProfile: (userCode: UserCode) -> Unit,
     navigateUp: () -> Unit,
@@ -107,7 +107,7 @@ fun SearchDetailScreen(
 
     SearchDetailScreen(
         keyword = uiState.keyword,
-        navigateToRecentSearch = navigateToRecentSearch,
+        navigateToRecentSearch = { navigateToRecentSearch(uiState.keyword) },
         searchedKeyword = uiState.searchedKeyword,
         loading = uiState.loading,
         shows = uiState.shows,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/recent/RecentSearchScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/recent/RecentSearchScreen.kt
@@ -23,14 +23,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.SpanStyle
@@ -142,9 +146,26 @@ private fun RecentSearchScreen(
     modifier: Modifier = Modifier,
 ) {
     val focusRequester = remember { FocusRequester() }
+    var textFieldValue by remember {
+        mutableStateOf(
+            TextFieldValue(
+                text = keyword,
+                selection = TextRange(keyword.length),
+            )
+        )
+    }
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
+    }
+
+    LaunchedEffect(keyword) {
+        if (textFieldValue.text != keyword) {
+            textFieldValue = TextFieldValue(
+                text = keyword,
+                selection = TextRange(keyword.length),
+            )
+        }
     }
 
     Scaffold(
@@ -163,14 +184,17 @@ private fun RecentSearchScreen(
                 .padding(horizontal = marginHorizontal),
         ) {
             BtSearchBar(
-                keyword = keyword,
-                onKeywordChanged = onKeywordChanged,
+                value = textFieldValue,
+                onValueChange = { newValue ->
+                    textFieldValue = newValue
+                    onKeywordChanged(newValue.text)
+                },
                 hint = stringResource(R.string.search_search_hint),
                 search = {
-                    search(keyword)
+                    search(textFieldValue.text)
                     AppTracker.search(
                         screen = Screen.Search,
-                        keyword = keyword,
+                        keyword = textFieldValue.text,
                         properties = mapOf(
                             "search_source" to "Direct",
                         ),
@@ -182,7 +206,7 @@ private fun RecentSearchScreen(
                     .padding(vertical = 12.dp),
             )
 
-            if (keyword.isEmpty()) {
+            if (textFieldValue.text.isEmpty()) {
                 EmptyKeywordContent(
                     recentKeywords = recentKeywords,
                     showClearButton = showClearButton,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/recent/RecentSearchViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/search/recent/RecentSearchViewModel.kt
@@ -1,7 +1,10 @@
 package com.nexters.boolti.presentation.screen.search.recent
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.nexters.boolti.domain.model.SearchHistory
+import com.nexters.boolti.presentation.screen.navigation.SearchRoute
 import com.nexters.boolti.domain.repository.SearchHistoryRepository
 import com.nexters.boolti.domain.repository.SearchRepository
 import com.nexters.boolti.presentation.base.BaseViewModel
@@ -23,10 +26,15 @@ import javax.inject.Inject
 
 @HiltViewModel
 class RecentSearchViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val searchHistoryRepository: SearchHistoryRepository,
     private val searchRepository: SearchRepository,
 ) : BaseViewModel() {
-    private val _uiState = MutableStateFlow(RecentSearchUiState.Mock) // TODO Mock 제거
+    private val route = savedStateHandle.toRoute<SearchRoute.RecentSearch>()
+
+    private val _uiState = MutableStateFlow(
+        RecentSearchUiState.Default.copy(keyword = route.keyword)
+    )
     val uiState = _uiState.asStateFlow()
 
     private val _event = Channel<RecentSearchEvent>()


### PR DESCRIPTION
## Summary
- SearchDetail에서 검색바 클릭 시 RecentSearch로 이동할 때 마지막 검색어와 결과 유지
- 검색어가 있을 경우 커서를 텍스트 끝에 위치
- BtSearchBar 컴포넌트 리팩토링 (TextFieldValue 오버로드 추가, 중복 코드 제거)

## Test plan
- [ ] SearchDetail에서 검색바 클릭 시 RecentSearch 화면으로 이동하면 이전 검색어가 유지되는지 확인
- [ ] 커서가 검색어 끝에 위치하는지 확인
- [ ] 홈에서 검색 화면 진입 시 기존처럼 빈 검색어로 시작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)