### PR TITLE
[Boolti-436] 사전질문 기능

### DIFF
--- a/data/src/main/java/com/nexters/boolti/data/datasource/ReservationDataSource.kt
+++ b/data/src/main/java/com/nexters/boolti/data/datasource/ReservationDataSource.kt
@@ -1,6 +1,7 @@
 package com.nexters.boolti.data.datasource
 
 import com.nexters.boolti.data.network.api.ReservationService
+import com.nexters.boolti.data.network.response.PreQuestionAnswerDetailResponse
 import com.nexters.boolti.data.network.response.ReservationDetailResponse
 import com.nexters.boolti.data.network.response.ReservationResponse
 import com.nexters.boolti.domain.request.RefundRequest
@@ -15,4 +16,7 @@ internal class ReservationDataSource @Inject constructor(
         reservationService.findReservationById(id)
 
     suspend fun refund(request: RefundRequest) = reservationService.refund(request)
+
+    suspend fun getPreQuestionAnswers(reservationId: String): PreQuestionAnswerDetailResponse =
+        reservationService.getPreQuestionAnswers(reservationId)
 }

--- a/data/src/main/java/com/nexters/boolti/data/datasource/TicketingDataSource.kt
+++ b/data/src/main/java/com/nexters/boolti/data/datasource/TicketingDataSource.kt
@@ -3,6 +3,8 @@ package com.nexters.boolti.data.datasource
 import com.nexters.boolti.data.network.api.TicketingService
 import com.nexters.boolti.data.network.request.ReservationInviteTicketRequest
 import com.nexters.boolti.data.network.request.ReservationSalesTicketRequest
+import com.nexters.boolti.data.network.request.SubmitPreQuestionAnswersRequestDto
+import com.nexters.boolti.domain.model.PreQuestion
 import com.nexters.boolti.data.network.response.ApprovePaymentResponse
 import com.nexters.boolti.data.network.response.CheckInviteCodeResponse
 import com.nexters.boolti.data.network.response.ReservationDto
@@ -61,5 +63,13 @@ internal class TicketingDataSource @Inject constructor(
     suspend fun cancelPayment(request: PaymentCancelRequest): Boolean {
         val response = ticketingService.cancelPayment(request)
         return response.isSuccessful && response.body() ?: false
+    }
+
+    suspend fun getPreQuestions(showId: String): List<PreQuestion> {
+        return ticketingService.getPreQuestions(showId).map { it.toDomain() }
+    }
+
+    suspend fun submitPreQuestionAnswers(request: SubmitPreQuestionAnswersRequestDto): Response<Unit> {
+        return ticketingService.submitPreQuestionAnswers(request)
     }
 }

--- a/data/src/main/java/com/nexters/boolti/data/network/api/ReservationService.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/api/ReservationService.kt
@@ -1,5 +1,6 @@
 package com.nexters.boolti.data.network.api
 
+import com.nexters.boolti.data.network.response.PreQuestionAnswerDetailResponse
 import com.nexters.boolti.data.network.response.ReservationDetailResponse
 import com.nexters.boolti.data.network.response.ReservationResponse
 import com.nexters.boolti.domain.request.RefundRequest
@@ -17,4 +18,7 @@ internal interface ReservationService {
 
     @PATCH("/app/api/v1/reservation/refund")
     suspend fun refund(@Body request: RefundRequest): Boolean
+
+    @GET("/app/api/v1/pre-question-answers/{reservationId}")
+    suspend fun getPreQuestionAnswers(@Path("reservationId") reservationId: String): PreQuestionAnswerDetailResponse
 }

--- a/data/src/main/java/com/nexters/boolti/data/network/api/TicketingService.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/api/TicketingService.kt
@@ -2,6 +2,8 @@ package com.nexters.boolti.data.network.api
 
 import com.nexters.boolti.data.network.request.ReservationInviteTicketRequest
 import com.nexters.boolti.data.network.request.ReservationSalesTicketRequest
+import com.nexters.boolti.data.network.request.SubmitPreQuestionAnswersRequestDto
+import com.nexters.boolti.data.network.response.PreQuestionDto
 import com.nexters.boolti.data.network.response.ApprovePaymentResponse
 import com.nexters.boolti.data.network.response.CheckInviteCodeResponse
 import com.nexters.boolti.data.network.response.OrderIdDto
@@ -15,6 +17,7 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -62,4 +65,14 @@ internal interface TicketingService {
     suspend fun cancelPayment(
         @Body request: PaymentCancelRequest
     ): Response<Boolean>
+
+    @GET("/app/api/v1/shows/{showId}/pre-questions")
+    suspend fun getPreQuestions(
+        @Path("showId") showId: String,
+    ): List<PreQuestionDto>
+
+    @PUT("/app/api/v1/pre-question-answers")
+    suspend fun submitPreQuestionAnswers(
+        @Body request: SubmitPreQuestionAnswersRequestDto,
+    ): Response<Unit>
 }

--- a/data/src/main/java/com/nexters/boolti/data/network/request/SubmitPreQuestionAnswersRequestDto.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/request/SubmitPreQuestionAnswersRequestDto.kt
@@ -1,0 +1,26 @@
+package com.nexters.boolti.data.network.request
+
+import com.nexters.boolti.domain.request.SubmitPreQuestionAnswersRequest
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class SubmitPreQuestionAnswersRequestDto(
+    val reservationId: Long,
+    val answers: List<PreQuestionAnswerDto>,
+)
+
+@Serializable
+internal data class PreQuestionAnswerDto(
+    val preQuestionId: Long,
+    val answer: String,
+)
+
+internal fun SubmitPreQuestionAnswersRequest.toData() = SubmitPreQuestionAnswersRequestDto(
+    reservationId = reservationId.toLong(),
+    answers = answers.map { answer ->
+        PreQuestionAnswerDto(
+            preQuestionId = answer.preQuestionId,
+            answer = answer.answer,
+        )
+    },
+)

--- a/data/src/main/java/com/nexters/boolti/data/network/response/PreQuestionAnswerResponse.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/response/PreQuestionAnswerResponse.kt
@@ -1,0 +1,32 @@
+package com.nexters.boolti.data.network.response
+
+import com.nexters.boolti.domain.model.PreQuestionAnswer
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class PreQuestionAnswerDetailResponse(
+    val reservationId: Long,
+    val userId: Long,
+    val answers: List<PreQuestionAnswerItemResponse>,
+)
+
+@Serializable
+internal data class PreQuestionAnswerItemResponse(
+    val preQuestionId: Long,
+    val question: String,
+    val description: String,
+    val isRequired: Boolean,
+    val answer: String,
+    val createdAt: String?,
+    val modifiedAt: String?,
+)
+
+internal fun PreQuestionAnswerItemResponse.toDomain() = PreQuestionAnswer(
+    preQuestionId = preQuestionId,
+    question = question,
+    description = description,
+    isRequired = isRequired,
+    answer = answer,
+)
+
+internal fun List<PreQuestionAnswerItemResponse>.toDomains() = map { it.toDomain() }

--- a/data/src/main/java/com/nexters/boolti/data/network/response/PreQuestionDto.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/response/PreQuestionDto.kt
@@ -1,0 +1,19 @@
+package com.nexters.boolti.data.network.response
+
+import com.nexters.boolti.domain.model.PreQuestion
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class PreQuestionDto(
+    val id: Long,
+    val question: String,
+    val description: String,
+    val isRequired: Boolean,
+) {
+    fun toDomain() = PreQuestion(
+        id = id,
+        question = question,
+        description = description,
+        isRequired = isRequired,
+    )
+}

--- a/data/src/main/java/com/nexters/boolti/data/repository/ReservationRepositoryImpl.kt
+++ b/data/src/main/java/com/nexters/boolti/data/repository/ReservationRepositoryImpl.kt
@@ -1,17 +1,22 @@
 package com.nexters.boolti.data.repository
 
 import com.nexters.boolti.data.datasource.ReservationDataSource
+import com.nexters.boolti.data.datasource.TicketingDataSource
+import com.nexters.boolti.data.network.request.toData
 import com.nexters.boolti.data.network.response.toDomains
+import com.nexters.boolti.domain.model.PreQuestionAnswer
 import com.nexters.boolti.domain.model.Reservation
 import com.nexters.boolti.domain.model.ReservationDetail
 import com.nexters.boolti.domain.repository.ReservationRepository
 import com.nexters.boolti.domain.request.RefundRequest
+import com.nexters.boolti.domain.request.SubmitPreQuestionAnswersRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 internal class ReservationRepositoryImpl @Inject constructor(
     private val reservationDataSource: ReservationDataSource,
+    private val ticketingDataSource: TicketingDataSource,
 ) : ReservationRepository {
     override fun getReservations(): Flow<List<Reservation>> = flow {
         emit(reservationDataSource.getReservations().toDomains())
@@ -27,6 +32,19 @@ internal class ReservationRepositoryImpl @Inject constructor(
             emit(Unit)
         } else {
             throw RuntimeException("취소 실패")
+        }
+    }
+
+    override fun getPreQuestionAnswers(reservationId: String): Flow<List<PreQuestionAnswer>> = flow {
+        emit(reservationDataSource.getPreQuestionAnswers(reservationId).answers.toDomains())
+    }
+
+    override fun updatePreQuestionAnswers(request: SubmitPreQuestionAnswersRequest): Flow<Unit> = flow {
+        val response = ticketingDataSource.submitPreQuestionAnswers(request.toData())
+        if (response.isSuccessful) {
+            emit(Unit)
+        } else {
+            throw RuntimeException("사전 질문 답변 저장 실패")
         }
     }
 }

--- a/data/src/main/java/com/nexters/boolti/data/repository/TicketingRepositoryImpl.kt
+++ b/data/src/main/java/com/nexters/boolti/data/repository/TicketingRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.nexters.boolti.domain.exception.TicketingException
 import com.nexters.boolti.domain.extension.errorType
 import com.nexters.boolti.domain.model.ApprovePaymentResponse
 import com.nexters.boolti.domain.model.InviteCodeStatus
+import com.nexters.boolti.domain.model.PreQuestion
 import com.nexters.boolti.domain.model.ReservationDetail
 import com.nexters.boolti.domain.model.TicketWithQuantity
 import com.nexters.boolti.domain.model.TicketingInfo
@@ -19,6 +20,7 @@ import com.nexters.boolti.domain.request.PaymentCancelRequest
 import com.nexters.boolti.domain.request.SalesTicketRequest
 import com.nexters.boolti.domain.request.TicketingInfoRequest
 import com.nexters.boolti.domain.request.TicketingRequest
+import com.nexters.boolti.domain.request.SubmitPreQuestionAnswersRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
@@ -83,5 +85,14 @@ internal class TicketingRepositoryImpl @Inject constructor(
 
     override fun cancelPayment(request: PaymentCancelRequest): Flow<Boolean> = flow {
         emit(dataSource.cancelPayment(request))
+    }
+
+    override fun getPreQuestions(showId: String): Flow<List<PreQuestion>> = flow {
+        emit(dataSource.getPreQuestions(showId))
+    }
+
+    override fun submitPreQuestionAnswers(request: SubmitPreQuestionAnswersRequest): Flow<Unit> = flow {
+        dataSource.submitPreQuestionAnswers(request.toData())
+        emit(Unit)
     }
 }

--- a/domain/src/main/java/com/nexters/boolti/domain/model/PreQuestion.kt
+++ b/domain/src/main/java/com/nexters/boolti/domain/model/PreQuestion.kt
@@ -1,0 +1,8 @@
+package com.nexters.boolti.domain.model
+
+data class PreQuestion(
+    val id: Long,
+    val question: String,
+    val description: String,
+    val isRequired: Boolean,
+)

--- a/domain/src/main/java/com/nexters/boolti/domain/model/PreQuestionAnswer.kt
+++ b/domain/src/main/java/com/nexters/boolti/domain/model/PreQuestionAnswer.kt
@@ -1,0 +1,9 @@
+package com.nexters.boolti.domain.model
+
+data class PreQuestionAnswer(
+    val preQuestionId: Long,
+    val question: String,
+    val description: String,
+    val isRequired: Boolean,
+    val answer: String,
+)

--- a/domain/src/main/java/com/nexters/boolti/domain/repository/ReservationRepository.kt
+++ b/domain/src/main/java/com/nexters/boolti/domain/repository/ReservationRepository.kt
@@ -1,12 +1,16 @@
 package com.nexters.boolti.domain.repository
 
+import com.nexters.boolti.domain.model.PreQuestionAnswer
 import com.nexters.boolti.domain.model.Reservation
 import com.nexters.boolti.domain.model.ReservationDetail
 import com.nexters.boolti.domain.request.RefundRequest
+import com.nexters.boolti.domain.request.SubmitPreQuestionAnswersRequest
 import kotlinx.coroutines.flow.Flow
 
 interface ReservationRepository {
     fun getReservations(): Flow<List<Reservation>>
     fun findReservationById(id: String): Flow<ReservationDetail>
     fun refund(request: RefundRequest): Flow<Unit>
+    fun getPreQuestionAnswers(reservationId: String): Flow<List<PreQuestionAnswer>>
+    fun updatePreQuestionAnswers(request: SubmitPreQuestionAnswersRequest): Flow<Unit>
 }

--- a/domain/src/main/java/com/nexters/boolti/domain/repository/TicketingRepository.kt
+++ b/domain/src/main/java/com/nexters/boolti/domain/repository/TicketingRepository.kt
@@ -12,6 +12,8 @@ import com.nexters.boolti.domain.request.PaymentCancelRequest
 import com.nexters.boolti.domain.request.SalesTicketRequest
 import com.nexters.boolti.domain.request.TicketingInfoRequest
 import com.nexters.boolti.domain.request.TicketingRequest
+import com.nexters.boolti.domain.model.PreQuestion
+import com.nexters.boolti.domain.request.SubmitPreQuestionAnswersRequest
 import kotlinx.coroutines.flow.Flow
 
 interface TicketingRepository {
@@ -23,4 +25,6 @@ interface TicketingRepository {
     fun requestOrderId(request: OrderIdRequest): Flow<String>
     fun approvePayment(request: PaymentApproveRequest): Flow<ApprovePaymentResponse>
     fun cancelPayment(request: PaymentCancelRequest): Flow<Boolean>
+    fun getPreQuestions(showId: String): Flow<List<PreQuestion>>
+    fun submitPreQuestionAnswers(request: SubmitPreQuestionAnswersRequest): Flow<Unit>
 }

--- a/domain/src/main/java/com/nexters/boolti/domain/request/SubmitPreQuestionAnswersRequest.kt
+++ b/domain/src/main/java/com/nexters/boolti/domain/request/SubmitPreQuestionAnswersRequest.kt
@@ -1,0 +1,11 @@
+package com.nexters.boolti.domain.request
+
+data class SubmitPreQuestionAnswersRequest(
+    val reservationId: String,
+    val answers: List<PreQuestionAnswerRequest>,
+)
+
+data class PreQuestionAnswerRequest(
+    val preQuestionId: Long,
+    val answer: String,
+)

--- a/presentation/src/main/java/com/nexters/boolti/presentation/extension/LifecycleEffect.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/extension/LifecycleEffect.kt
@@ -1,0 +1,32 @@
+package com.nexters.boolti.presentation.extension
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+@Composable
+fun OnLifecycleEvent(
+    event: Lifecycle.Event,
+    onEvent: () -> Unit,
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, e ->
+            if (e == event) onEvent()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+}
+
+@Composable
+fun OnResume(onResume: () -> Unit) {
+    OnLifecycleEvent(Lifecycle.Event.ON_RESUME, onResume)
+}
+
+@Composable
+fun OnStart(onStart: () -> Unit) {
+    OnLifecycleEvent(Lifecycle.Event.ON_START, onStart)
+}

--- a/presentation/src/main/java/com/nexters/boolti/presentation/extension/String.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/extension/String.kt
@@ -72,6 +72,15 @@ fun String.takeForUnicode(n: Int): String {
     return substring(0, endIndex)
 }
 
+fun String.unicodeLength(): Int {
+    val iterator = BreakIterator.getCharacterInstance().apply { setText(this@unicodeLength) }
+    var count = 0
+    while (iterator.next() != BreakIterator.DONE) {
+        count++
+    }
+    return count
+}
+
 fun String.toValidUrlString(): String = runCatching {
     if (URL(this).protocol.isNullOrEmpty()) "https://$this" else this
 }.recoverCatching { e ->

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/Main.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/Main.kt
@@ -42,6 +42,7 @@ import com.nexters.boolti.presentation.screen.navigation.TicketRoute
 import com.nexters.boolti.presentation.screen.navigation.VideoListRoute
 import com.nexters.boolti.presentation.screen.payment.paymentCompleteScreen
 import com.nexters.boolti.presentation.screen.perforemdshows.performedShowsScreen
+import com.nexters.boolti.presentation.screen.prequestionedit.preQuestionEditScreen
 import com.nexters.boolti.presentation.screen.profile.profileScreen
 import com.nexters.boolti.presentation.screen.profileedit.introduce.profileIntroduceEditScreen
 import com.nexters.boolti.presentation.screen.profileedit.link.linkEditScreen
@@ -140,6 +141,7 @@ fun MainNavigation(
         signoutScreen()
         reservationsScreen()
         reservationDetailScreen()
+        preQuestionEditScreen()
         refundScreen()
 
         navigation<ShowRoute.ShowRoot>(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/navigation/MainRoute.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/navigation/MainRoute.kt
@@ -72,4 +72,9 @@ sealed interface MainRoute {
     data class PerformedShows(
         val userCode: String,
     ) : MainRoute
+
+    @Serializable
+    data class PreQuestionEdit(
+        val reservationId: String,
+    ) : MainRoute
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditEvent.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditEvent.kt
@@ -1,6 +1,6 @@
 package com.nexters.boolti.presentation.screen.prequestionedit
 
 sealed interface PreQuestionEditEvent {
-    data object SaveSuccess : PreQuestionEditEvent
+    data class SaveSuccess(val hasChanges: Boolean) : PreQuestionEditEvent
     data class SaveError(val message: String) : PreQuestionEditEvent
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditEvent.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditEvent.kt
@@ -1,0 +1,6 @@
+package com.nexters.boolti.presentation.screen.prequestionedit
+
+sealed interface PreQuestionEditEvent {
+    data object SaveSuccess : PreQuestionEditEvent
+    data class SaveError(val message: String) : PreQuestionEditEvent
+}

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditIntent.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditIntent.kt
@@ -1,0 +1,6 @@
+package com.nexters.boolti.presentation.screen.prequestionedit
+
+sealed interface PreQuestionEditIntent {
+    data class SetAnswer(val questionId: Long, val answer: String) : PreQuestionEditIntent
+    data object Submit : PreQuestionEditIntent
+}

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditNavigation.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditNavigation.kt
@@ -1,0 +1,15 @@
+package com.nexters.boolti.presentation.screen.prequestionedit
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.nexters.boolti.presentation.screen.LocalNavController
+import com.nexters.boolti.presentation.screen.navigation.MainRoute
+
+fun NavGraphBuilder.preQuestionEditScreen() {
+    composable<MainRoute.PreQuestionEdit> {
+        val navController = LocalNavController.current
+        PreQuestionEditScreen(
+            onBackPressed = navController::navigateUp,
+        )
+    }
+}

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditScreen.kt
@@ -1,0 +1,166 @@
+package com.nexters.boolti.presentation.screen.prequestionedit
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.nexters.boolti.domain.model.PreQuestionAnswer
+import com.nexters.boolti.presentation.R
+import com.nexters.boolti.presentation.component.BTTextField
+import com.nexters.boolti.presentation.component.BtBackAppBar
+import com.nexters.boolti.presentation.component.MainButton
+import com.nexters.boolti.presentation.extension.unicodeLength
+import com.nexters.boolti.presentation.theme.Grey50
+import com.nexters.boolti.presentation.theme.marginHorizontal
+import kotlinx.coroutines.flow.collectLatest
+
+@Composable
+fun PreQuestionEditScreen(
+    onBackPressed: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PreQuestionEditViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collectLatest { event ->
+            when (event) {
+                is PreQuestionEditEvent.SaveSuccess -> onBackPressed()
+                is PreQuestionEditEvent.SaveError -> Unit
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.navigationBarsPadding(),
+        topBar = {
+            BtBackAppBar(
+                title = stringResource(R.string.pre_question_edit_title),
+                onClickBack = onBackPressed,
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .background(MaterialTheme.colorScheme.surface),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = marginHorizontal)
+                    .padding(bottom = 100.dp),
+            ) {
+                Spacer(modifier = Modifier.height(20.dp))
+                uiState.questions.forEachIndexed { index, question ->
+                    if (index > 0) {
+                        Spacer(modifier = Modifier.height(32.dp))
+                    }
+                    PreQuestionEditItem(
+                        question = question,
+                        answer = uiState.answers[question.preQuestionId] ?: "",
+                        isError = uiState.isError(question.preQuestionId),
+                        onAnswerChanged = { answer ->
+                            viewModel.onIntent(PreQuestionEditIntent.SetAnswer(question.preQuestionId, answer))
+                        },
+                    )
+                }
+            }
+
+            MainButton(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.background)
+                    .padding(horizontal = marginHorizontal)
+                    .padding(vertical = 20.dp),
+                label = stringResource(R.string.complete),
+                enabled = uiState.isValid && !uiState.loading,
+                onClick = { viewModel.onIntent(PreQuestionEditIntent.Submit) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun PreQuestionEditItem(
+    question: PreQuestionAnswer,
+    answer: String,
+    isError: Boolean,
+    onAnswerChanged: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Row {
+            Text(
+                text = question.question,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (question.isRequired) {
+                Text(
+                    modifier = Modifier.padding(start = 4.dp),
+                    text = "*",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+
+        if (question.description.isNotBlank()) {
+            Text(
+                modifier = Modifier.padding(top = 4.dp),
+                text = question.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = Grey50,
+            )
+        }
+
+        BTTextField(
+            modifier = Modifier
+                .padding(top = 16.dp)
+                .fillMaxWidth(),
+            text = answer,
+            onValueChanged = onAnswerChanged,
+            placeholder = stringResource(R.string.pre_question_placeholder),
+            minHeight = 160.dp,
+            isError = isError,
+            bottomEndText = stringResource(
+                R.string.input_limit,
+                answer.unicodeLength(),
+                PreQuestionEditUiState.MAX_ANSWER_LENGTH,
+            ),
+            supportingText = if (isError) {
+                stringResource(R.string.input_upper_limit_text, PreQuestionEditUiState.MAX_ANSWER_LENGTH)
+            } else null,
+            keyboardOptions = KeyboardOptions.Default.copy(
+                imeAction = ImeAction.Default,
+            ),
+        )
+    }
+}

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditScreen.kt
@@ -33,6 +33,7 @@ import com.nexters.boolti.presentation.component.BTTextField
 import com.nexters.boolti.presentation.component.BtBackAppBar
 import com.nexters.boolti.presentation.component.MainButton
 import com.nexters.boolti.presentation.extension.unicodeLength
+import com.nexters.boolti.presentation.screen.LocalSnackbarController
 import com.nexters.boolti.presentation.theme.Grey50
 import com.nexters.boolti.presentation.theme.marginHorizontal
 import kotlinx.coroutines.flow.collectLatest
@@ -44,11 +45,18 @@ fun PreQuestionEditScreen(
     viewModel: PreQuestionEditViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarController = LocalSnackbarController.current
+    val saveCompleteMessage = stringResource(R.string.pre_question_save_complete)
 
     LaunchedEffect(Unit) {
         viewModel.events.collectLatest { event ->
             when (event) {
-                is PreQuestionEditEvent.SaveSuccess -> onBackPressed()
+                is PreQuestionEditEvent.SaveSuccess -> {
+                    if (event.hasChanges) {
+                        snackbarController.showMessage(saveCompleteMessage)
+                    }
+                    onBackPressed()
+                }
                 is PreQuestionEditEvent.SaveError -> Unit
             }
         }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditUiState.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditUiState.kt
@@ -1,0 +1,23 @@
+package com.nexters.boolti.presentation.screen.prequestionedit
+
+import com.nexters.boolti.domain.model.PreQuestionAnswer
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.persistentSetOf
+
+data class PreQuestionEditUiState(
+    val loading: Boolean = true,
+    val questions: ImmutableList<PreQuestionAnswer> = persistentListOf(),
+    val answers: ImmutableMap<Long, String> = persistentMapOf(),
+    val answerErrors: ImmutableSet<Long> = persistentSetOf(),
+    val isValid: Boolean = false,
+) {
+    fun isError(questionId: Long): Boolean = questionId in answerErrors
+
+    companion object {
+        const val MAX_ANSWER_LENGTH = 100
+    }
+}

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditViewModel.kt
@@ -46,6 +46,8 @@ class PreQuestionEditViewModel @Inject constructor(
     private val _events = Channel<PreQuestionEditEvent>()
     val events: Flow<PreQuestionEditEvent> = _events.receiveAsFlow()
 
+    private var initialAnswers: ImmutableMap<Long, String>? = null
+
     init {
         fetchPreQuestionAnswers()
     }
@@ -69,11 +71,12 @@ class PreQuestionEditViewModel @Inject constructor(
                 _uiState.update { it.copy(loading = true) }
             }
             .onEach { answerList ->
+                val questions = answerList.toImmutableList()
+                val answers = answerList.associate { answer ->
+                    answer.preQuestionId to answer.answer
+                }.toImmutableMap()
+                initialAnswers = answers
                 _uiState.update {
-                    val questions = answerList.toImmutableList()
-                    val answers = answerList.associate { answer ->
-                        answer.preQuestionId to answer.answer
-                    }.toImmutableMap()
                     it.copy(
                         loading = false,
                         questions = questions,
@@ -148,8 +151,9 @@ class PreQuestionEditViewModel @Inject constructor(
                 _uiState.update { it.copy(loading = true) }
             }
             .onEach {
+                val hasChanges = initialAnswers != state.answers
                 _uiState.update { it.copy(loading = false) }
-                sendEvent(PreQuestionEditEvent.SaveSuccess)
+                sendEvent(PreQuestionEditEvent.SaveSuccess(hasChanges))
             }
             .catch { e ->
                 Timber.e(e, "Failed to submit pre-question answers")

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditViewModel.kt
@@ -1,0 +1,161 @@
+package com.nexters.boolti.presentation.screen.prequestionedit
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.nexters.boolti.domain.model.PreQuestionAnswer
+import com.nexters.boolti.domain.repository.ReservationRepository
+import com.nexters.boolti.domain.request.PreQuestionAnswerRequest
+import com.nexters.boolti.domain.request.SubmitPreQuestionAnswersRequest
+import com.nexters.boolti.presentation.base.BaseViewModel
+import com.nexters.boolti.presentation.extension.unicodeLength
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableMap
+import kotlinx.collections.immutable.toImmutableSet
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class PreQuestionEditViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val reservationRepository: ReservationRepository,
+) : BaseViewModel() {
+
+    private val reservationId: String = checkNotNull(savedStateHandle["reservationId"]) {
+        "reservationId가 전달되어야 합니다."
+    }
+
+    private val _uiState = MutableStateFlow(PreQuestionEditUiState())
+    val uiState: StateFlow<PreQuestionEditUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<PreQuestionEditEvent>()
+    val events: Flow<PreQuestionEditEvent> = _events.receiveAsFlow()
+
+    init {
+        fetchPreQuestionAnswers()
+    }
+
+    fun onIntent(intent: PreQuestionEditIntent) {
+        when (intent) {
+            is PreQuestionEditIntent.SetAnswer -> setAnswer(intent.questionId, intent.answer)
+            is PreQuestionEditIntent.Submit -> submitAnswers()
+        }
+    }
+
+    private fun sendEvent(event: PreQuestionEditEvent) {
+        viewModelScope.launch {
+            _events.send(event)
+        }
+    }
+
+    private fun fetchPreQuestionAnswers() {
+        reservationRepository.getPreQuestionAnswers(reservationId)
+            .onStart {
+                _uiState.update { it.copy(loading = true) }
+            }
+            .onEach { answerList ->
+                _uiState.update {
+                    val questions = answerList.toImmutableList()
+                    val answers = answerList.associate { answer ->
+                        answer.preQuestionId to answer.answer
+                    }.toImmutableMap()
+                    it.copy(
+                        loading = false,
+                        questions = questions,
+                        answers = answers,
+                        answerErrors = calculateAnswerErrors(answers),
+                        isValid = calculateValidity(questions, answers),
+                    )
+                }
+            }
+            .catch { e ->
+                Timber.e(e, "Failed to fetch pre-question answers")
+                _uiState.update { it.copy(loading = false) }
+                sendEvent(PreQuestionEditEvent.SaveError(e.message ?: ""))
+            }
+            .launchIn(viewModelScope + recordExceptionHandler)
+    }
+
+    private fun setAnswer(questionId: Long, answer: String) {
+        _uiState.update {
+            val newAnswers = it.answers.toMutableMap()
+            newAnswers[questionId] = answer
+            val immutableAnswers = newAnswers.toImmutableMap()
+            it.copy(
+                answers = immutableAnswers,
+                answerErrors = calculateAnswerErrors(immutableAnswers),
+                isValid = calculateValidity(it.questions, immutableAnswers),
+            )
+        }
+    }
+
+    private fun calculateAnswerErrors(answers: ImmutableMap<Long, String>) =
+        answers.filterValues { it.unicodeLength() > PreQuestionEditUiState.MAX_ANSWER_LENGTH }
+            .keys
+            .toImmutableSet()
+
+    private fun calculateValidity(
+        questions: ImmutableList<PreQuestionAnswer>,
+        answers: ImmutableMap<Long, String>,
+    ): Boolean {
+        val requiredAnswered = questions
+            .filter { it.isRequired }
+            .all { question ->
+                val answer = answers[question.preQuestionId]
+                !answer.isNullOrBlank() && answer.unicodeLength() <= PreQuestionEditUiState.MAX_ANSWER_LENGTH
+            }
+
+        val noInvalidAnswers = answers.values.none {
+            it.unicodeLength() > PreQuestionEditUiState.MAX_ANSWER_LENGTH
+        }
+
+        return requiredAnswered && noInvalidAnswers
+    }
+
+    private fun submitAnswers() {
+        val state = uiState.value
+        val answerRequests = state.answers
+            .filter { (_, answer) -> answer.isNotBlank() }
+            .map { (questionId, answer) ->
+                PreQuestionAnswerRequest(
+                    preQuestionId = questionId,
+                    answer = answer,
+                )
+            }
+
+        val request = SubmitPreQuestionAnswersRequest(
+            reservationId = reservationId,
+            answers = answerRequests,
+        )
+
+        reservationRepository.updatePreQuestionAnswers(request)
+            .onStart {
+                _uiState.update { it.copy(loading = true) }
+            }
+            .onEach {
+                _uiState.update { it.copy(loading = false) }
+                sendEvent(PreQuestionEditEvent.SaveSuccess)
+            }
+            .catch { e ->
+                Timber.e(e, "Failed to submit pre-question answers")
+                _uiState.update { it.copy(loading = false) }
+                sendEvent(PreQuestionEditEvent.SaveError(e.message ?: ""))
+            }
+            .launchIn(viewModelScope + recordExceptionHandler)
+    }
+}

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/PreQuestionAnswersSection.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/PreQuestionAnswersSection.kt
@@ -1,6 +1,7 @@
 package com.nexters.boolti.presentation.screen.reservationdetail
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -79,10 +80,16 @@ private fun PreQuestionAnswerItem(
     answer: PreQuestionAnswer,
     modifier: Modifier = Modifier,
 ) {
+    val shape = RoundedCornerShape(8.dp)
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
+            .clip(shape)
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.outline,
+                shape = shape,
+            )
             .background(Grey85)
             .padding(16.dp),
     ) {

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/PreQuestionAnswersSection.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/PreQuestionAnswersSection.kt
@@ -1,0 +1,135 @@
+package com.nexters.boolti.presentation.screen.reservationdetail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.nexters.boolti.domain.model.PreQuestionAnswer
+import com.nexters.boolti.presentation.R
+import com.nexters.boolti.presentation.component.MainButton
+import com.nexters.boolti.presentation.component.MainButtonDefaults
+import com.nexters.boolti.presentation.theme.Grey30
+import com.nexters.boolti.presentation.theme.Grey50
+import com.nexters.boolti.presentation.theme.Grey60
+import com.nexters.boolti.presentation.theme.Grey70
+import com.nexters.boolti.presentation.theme.Grey85
+import kotlinx.collections.immutable.ImmutableList
+import java.time.LocalDateTime
+
+@Composable
+internal fun PreQuestionAnswersSection(
+    answers: ImmutableList<PreQuestionAnswer>,
+    salesEndDateTime: LocalDateTime,
+    onNavigateToEdit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (answers.isEmpty()) return
+
+    val hasAnswers = answers.any { it.answer.isNotBlank() }
+    val canEdit = salesEndDateTime >= LocalDateTime.now()
+
+    Section(
+        modifier = modifier,
+        title = stringResource(R.string.pre_questions_label),
+        defaultExpanded = true,
+    ) {
+        answers.forEachIndexed { index, answer ->
+            if (index > 0) {
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+            PreQuestionAnswerItem(answer = answer)
+        }
+
+        if (canEdit) {
+            MainButton(
+                modifier = Modifier
+                    .padding(top = 20.dp)
+                    .fillMaxWidth(),
+                label = stringResource(
+                    if (hasAnswers) R.string.pre_question_edit_button
+                    else R.string.pre_question_create_button,
+                ),
+                colors = MainButtonDefaults.buttonColors(
+                    containerColor = if (hasAnswers) Grey70 else MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ),
+                onClick = onNavigateToEdit,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PreQuestionAnswerItem(
+    answer: PreQuestionAnswer,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(Grey85)
+            .padding(16.dp),
+    ) {
+        Row {
+            Text(
+                text = answer.question,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (answer.isRequired) {
+                Text(
+                    modifier = Modifier.padding(start = 4.dp),
+                    text = "*",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+
+        if (answer.description.isNotBlank()) {
+            Text(
+                modifier = Modifier.padding(top = 4.dp),
+                text = answer.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = Grey30,
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .padding(top = 12.dp)
+                .height(IntrinsicSize.Min),
+        ) {
+            Box(
+                modifier = Modifier
+                    .padding(end = 16.dp)
+                    .width(3.dp)
+                    .fillMaxHeight()
+                    .background(Grey60),
+            )
+            Text(
+                text = answer.answer.ifBlank {
+                    stringResource(R.string.pre_question_no_answer)
+                },
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (answer.answer.isBlank()) Grey50 else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailNavigation.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailNavigation.kt
@@ -13,6 +13,9 @@ fun NavGraphBuilder.reservationDetailScreen() {
             navigateToRefund = { id, isGift ->
                 navController.navigate(MainRoute.Refund(reservationId = id, isGift = isGift))
             },
+            navigateToPreQuestionEdit = { reservationId ->
+                navController.navigate(MainRoute.PreQuestionEdit(reservationId = reservationId))
+            },
         )
     }
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailScreen.kt
@@ -22,12 +22,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -53,6 +49,7 @@ import com.nexters.boolti.presentation.component.BtBackAppBar
 import com.nexters.boolti.presentation.component.MainButton
 import com.nexters.boolti.presentation.component.MainButtonDefaults
 import com.nexters.boolti.presentation.component.ShowItemV2
+import com.nexters.boolti.presentation.extension.OnResume
 import com.nexters.boolti.presentation.extension.getPaymentString
 import com.nexters.boolti.presentation.extension.toDescriptionAndColorPair
 import com.nexters.boolti.presentation.screen.giftcomplete.GiftPolicy
@@ -81,18 +78,7 @@ fun ReservationDetailScreen(
         viewModel.fetchReservation()
     }
 
-    val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) {
-                viewModel.refreshPreQuestionAnswers()
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
-        }
-    }
+    OnResume { viewModel.refreshPreQuestionAnswers() }
 
     Scaffold(
         modifier = modifier.navigationBarsPadding(),

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailScreen.kt
@@ -22,8 +22,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -64,15 +68,30 @@ import com.nexters.boolti.presentation.theme.marginHorizontal
 fun ReservationDetailScreen(
     onBackPressed: () -> Unit,
     navigateToRefund: (id: String, isGift: Boolean) -> Unit,
+    navigateToPreQuestionEdit: (reservationId: String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: ReservationDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val refundPolicy by viewModel.refundPolicy.collectAsStateWithLifecycle()
+    val preQuestionAnswers by viewModel.preQuestionAnswers.collectAsStateWithLifecycle()
     var showRefundDialog by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.fetchReservation()
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshPreQuestionAnswers()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
     }
 
     Scaffold(
@@ -135,6 +154,12 @@ fun ReservationDetailScreen(
             }
             TicketInfo(reservation = state.reservation)
             PaymentInfo(reservation = state.reservation)
+            PreQuestionAnswersSection(
+                modifier = Modifier.padding(top = 12.dp),
+                answers = preQuestionAnswers,
+                salesEndDateTime = state.reservation.salesEndDateTime,
+                onNavigateToEdit = { navigateToPreQuestionEdit(state.reservation.id) },
+            )
             if (state.reservation.reservationState in listOf(
                     ReservationState.REFUNDED,
                     ReservationState.CANCELED
@@ -414,7 +439,7 @@ private fun NormalRow(
 }
 
 @Composable
-private fun Section(
+internal fun Section(
     title: String,
     modifier: Modifier = Modifier,
     defaultExpanded: Boolean = true,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailViewModel.kt
@@ -2,11 +2,15 @@ package com.nexters.boolti.presentation.screen.reservationdetail
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.nexters.boolti.domain.model.PreQuestionAnswer
 import com.nexters.boolti.domain.repository.GiftRepository
 import com.nexters.boolti.domain.repository.ReservationRepository
 import com.nexters.boolti.domain.usecase.GetRefundPolicyUsecase
 import com.nexters.boolti.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,6 +20,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.plus
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -38,6 +43,9 @@ class ReservationDetailViewModel @Inject constructor(
     private val _refundPolicy = MutableStateFlow<List<String>>(emptyList())
     val refundPolicy = _refundPolicy.asStateFlow()
 
+    private val _preQuestionAnswers = MutableStateFlow<ImmutableList<PreQuestionAnswer>>(persistentListOf())
+    val preQuestionAnswers: StateFlow<ImmutableList<PreQuestionAnswer>> = _preQuestionAnswers.asStateFlow()
+
     init {
         fetchRefundPolicy()
     }
@@ -55,10 +63,26 @@ class ReservationDetailViewModel @Inject constructor(
             }
             .onEach { reservation ->
                 _uiState.update { ReservationDetailUiState.Success(reservation) }
+                fetchPreQuestionAnswers()
             }
             .catch {
                 _uiState.update { ReservationDetailUiState.Error() }
                 throw it
+            }
+            .launchIn(viewModelScope + recordExceptionHandler)
+    }
+
+    fun refreshPreQuestionAnswers() {
+        fetchPreQuestionAnswers()
+    }
+
+    private fun fetchPreQuestionAnswers() {
+        reservationRepository.getPreQuestionAnswers(reservationId)
+            .onEach { answers ->
+                _preQuestionAnswers.value = answers.toImmutableList()
+            }
+            .catch { e ->
+                Timber.e(e, "Failed to fetch pre-question answers")
             }
             .launchIn(viewModelScope + recordExceptionHandler)
     }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/PreQuestionsSection.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/PreQuestionsSection.kt
@@ -1,0 +1,106 @@
+package com.nexters.boolti.presentation.screen.ticketing
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.nexters.boolti.domain.model.PreQuestion
+import com.nexters.boolti.presentation.R
+import com.nexters.boolti.presentation.extension.unicodeLength
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
+import com.nexters.boolti.presentation.component.BTTextField
+import com.nexters.boolti.presentation.theme.Grey50
+
+@Composable
+internal fun PreQuestionsSection(
+    preQuestions: ImmutableList<PreQuestion>,
+    answers: ImmutableMap<Long, String>,
+    onAnswerChanged: (Long, String) -> Unit,
+    getAnswerError: (Long) -> Boolean,
+    modifier: Modifier = Modifier,
+) {
+    if (preQuestions.isEmpty()) return
+
+    Section(
+        modifier = modifier,
+        title = stringResource(R.string.pre_questions_label),
+    ) {
+        preQuestions.forEachIndexed { index, question ->
+            PreQuestionItem(
+                question = question,
+                answer = answers[question.id] ?: "",
+                isError = getAnswerError(question.id),
+                onAnswerChanged = { onAnswerChanged(question.id, it) },
+            )
+            if (index < preQuestions.lastIndex) {
+                Spacer(modifier = Modifier.height(32.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreQuestionItem(
+    question: PreQuestion,
+    answer: String,
+    isError: Boolean,
+    onAnswerChanged: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Row {
+            Text(
+                text = question.question,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (question.isRequired) {
+                Text(
+                    modifier = Modifier.padding(start = 4.dp),
+                    text = "*",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+
+        if (question.description.isNotBlank()) {
+            Text(
+                modifier = Modifier.padding(top = 4.dp),
+                text = question.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = Grey50,
+            )
+        }
+
+        BTTextField(
+            modifier = Modifier
+                .padding(top = 16.dp)
+                .fillMaxWidth(),
+            text = answer,
+            onValueChanged = onAnswerChanged,
+            placeholder = stringResource(R.string.pre_question_placeholder),
+            minHeight = 160.dp,
+            isError = isError,
+            bottomEndText = stringResource(R.string.input_limit, answer.unicodeLength(), TicketingState.MAX_ANSWER_LENGTH),
+            supportingText = if (isError) {
+                stringResource(R.string.input_upper_limit_text, TicketingState.MAX_ANSWER_LENGTH)
+            } else null,
+            keyboardOptions = KeyboardOptions.Default.copy(
+                imeAction = ImeAction.Default,
+            ),
+        )
+    }
+}

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingScreen.kt
@@ -143,6 +143,8 @@ fun TicketingScreen(
         onInviteCodeChanged = viewModel::setInviteCode,
         onToggleAgreement = viewModel::toggleAgreement,
         onClickReservation = viewModel::reservation,
+        onChangePreQuestionAnswer = viewModel::setPreQuestionAnswer,
+        onSubmitPreQuestionAnswers = viewModel::submitPreQuestionAnswersForReservation,
         modifier = modifier,
     )
 }
@@ -165,6 +167,8 @@ private fun TicketingScreen(
     onInviteCodeChanged: (String) -> Unit,
     onToggleAgreement: () -> Unit,
     onClickReservation: () -> Unit,
+    onChangePreQuestionAnswer: (Long, String) -> Unit,
+    onSubmitPreQuestionAnswers: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -198,6 +202,7 @@ private fun TicketingScreen(
                         ),
                     )
 
+                    onSubmitPreQuestionAnswers(reservationId)
                     onReserved(reservationId, showId)
                 }
 
@@ -326,6 +331,14 @@ private fun TicketingScreen(
                         onInviteCodeChanged = onInviteCodeChanged,
                     )
                 }
+
+                // 사전 질문
+                PreQuestionsSection(
+                    preQuestions = uiState.preQuestions,
+                    answers = uiState.preQuestionAnswers,
+                    onAnswerChanged = onChangePreQuestionAnswer,
+                    getAnswerError = uiState::getAnswerError,
+                )
 
                 if (!uiState.isInviteTicket) RefundPolicySection(uiState.refundPolicy) // 취소/환불 규정
 
@@ -889,6 +902,8 @@ private fun TicketingDetailScreenPreview() {
                 onClickCheckInviteCode = {},
                 onInviteCodeChanged = {},
                 onClickReservation = {},
+                onChangePreQuestionAnswer = { _, _ -> },
+                onSubmitPreQuestionAnswers = {},
             )
         }
     }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingState.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingState.kt
@@ -1,7 +1,13 @@
 package com.nexters.boolti.presentation.screen.ticketing
 
 import com.nexters.boolti.domain.model.InviteCodeStatus
+import com.nexters.boolti.domain.model.PreQuestion
 import com.nexters.boolti.presentation.R
+import com.nexters.boolti.presentation.extension.unicodeLength
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
 import java.time.LocalDateTime
 
 data class TicketingState(
@@ -25,23 +31,50 @@ data class TicketingState(
         Pair(R.string.order_agreement_privacy_collection, false),
         Pair(R.string.order_agreement_privacy_offer, false),
     ),
+    val preQuestions: ImmutableList<PreQuestion> = persistentListOf(),
+    val preQuestionAnswers: ImmutableMap<Long, String> = persistentMapOf(),
 ) {
     val orderAgreed: Boolean
         get() = orderAgreement.none { !it.second }
 
-    val reservationButtonEnabled: Boolean
+    private val isBasicInfoValid: Boolean
+        get() = orderAgreed &&
+                reservationName.isNotBlank() &&
+                reservationContact.isNotBlank()
+
+    private val isRequiredQuestionsAnswered: Boolean
+        get() = preQuestions
+            .filter { it.isRequired }
+            .all { question ->
+                val answer = preQuestionAnswers[question.id]
+                !answer.isNullOrBlank() && answer.unicodeLength() <= MAX_ANSWER_LENGTH
+            }
+
+    private val hasInvalidAnswers: Boolean
+        get() = preQuestionAnswers.values.any { it.unicodeLength() > MAX_ANSWER_LENGTH }
+
+    private val isPreQuestionsValid: Boolean
+        get() = isRequiredQuestionsAnswered && !hasInvalidAnswers
+
+    private val isPaymentInfoValid: Boolean
         get() = when {
-            !orderAgreed ||
-                    reservationName.isBlank() ||
-                    reservationContact.isBlank() -> false
-
             isInviteTicket -> inviteCodeStatus is InviteCodeStatus.Valid
-
             totalPrice == 0 -> true
-
-            else -> (isSameContactInfo || depositorName.isNotBlank()) &&
-                    (isSameContactInfo || depositorContact.isNotBlank())
+            else -> isSameContactInfo ||
+                    (depositorName.isNotBlank() && depositorContact.isNotBlank())
         }
 
+    val reservationButtonEnabled: Boolean
+        get() = isBasicInfoValid && isPreQuestionsValid && isPaymentInfoValid
+
+    fun getAnswerError(questionId: Long): Boolean {
+        val answer = preQuestionAnswers[questionId] ?: return false
+        return answer.unicodeLength() > MAX_ANSWER_LENGTH
+    }
+
     fun toggleAgreement(): TicketingState = copy(orderAgreement = orderAgreement.map { it.copy(second = !orderAgreed) })
+
+    companion object {
+        const val MAX_ANSWER_LENGTH = 100
+    }
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingViewModel.kt
@@ -10,6 +10,8 @@ import com.nexters.boolti.domain.request.CheckInviteCodeRequest
 import com.nexters.boolti.domain.request.OrderIdRequest
 import com.nexters.boolti.domain.request.TicketingInfoRequest
 import com.nexters.boolti.domain.request.TicketingRequest
+import com.nexters.boolti.domain.request.SubmitPreQuestionAnswersRequest
+import com.nexters.boolti.domain.request.PreQuestionAnswerRequest
 import com.nexters.boolti.domain.usecase.GetRefundPolicyUsecase
 import com.nexters.boolti.domain.usecase.GetUserUsecase
 import com.nexters.boolti.presentation.base.BaseViewModel
@@ -29,6 +31,8 @@ import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableMap
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -94,6 +98,7 @@ class TicketingViewModel @Inject constructor(
             .onCompletion { _uiState.update { it.copy(loading = false) } }
             .singleOrNull()?.let { reservationId ->
                 Timber.tag("MANGBAAM-TicketingViewModel(reservation)").d("예매 성공: $reservationId")
+                submitPreQuestionAnswers(reservationId)
                 event(TicketingEvent.TicketingSuccess(reservationId, showId))
             }
     }
@@ -121,8 +126,9 @@ class TicketingViewModel @Inject constructor(
                 }
             }
             .singleOrNull()?.let { reservationId ->
-            event(TicketingEvent.TicketingSuccess(reservationId, showId))
-        }
+                submitPreQuestionAnswers(reservationId)
+                event(TicketingEvent.TicketingSuccess(reservationId, showId))
+            }
     }
 
     private fun load() {
@@ -150,6 +156,17 @@ class TicketingViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(refundPolicy = refundPolicy)
                     }
+                }
+                .launchIn(viewModelScope + recordExceptionHandler)
+
+            repository.getPreQuestions(showId)
+                .onEach { preQuestions ->
+                    _uiState.update {
+                        it.copy(preQuestions = preQuestions.toImmutableList())
+                    }
+                }
+                .catch { e ->
+                    Timber.e(e, "Failed to load pre-questions")
                 }
                 .launchIn(viewModelScope + recordExceptionHandler)
         }
@@ -204,6 +221,46 @@ class TicketingViewModel @Inject constructor(
 
     fun toggleAgreement() {
         _uiState.update { it.toggleAgreement() }
+    }
+
+    fun setPreQuestionAnswer(questionId: Long, answer: String) {
+        _uiState.update {
+            val newAnswers = it.preQuestionAnswers.toMutableMap()
+            newAnswers[questionId] = answer
+            it.copy(preQuestionAnswers = newAnswers.toImmutableMap())
+        }
+    }
+
+    private suspend fun submitPreQuestionAnswers(reservationId: String) {
+        if (state.preQuestions.isEmpty()) return
+
+        val answers = state.preQuestionAnswers
+            .filter { (_, answer) -> answer.isNotBlank() }
+            .map { (questionId, answer) ->
+                PreQuestionAnswerRequest(
+                    preQuestionId = questionId,
+                    answer = answer,
+                )
+            }
+
+        if (answers.isEmpty()) return
+
+        val request = SubmitPreQuestionAnswersRequest(
+            reservationId = reservationId,
+            answers = answers,
+        )
+
+        repository.submitPreQuestionAnswers(request)
+            .catch { e ->
+                Timber.e(e, "Failed to submit pre-question answers")
+            }
+            .firstOrNull()
+    }
+
+    fun submitPreQuestionAnswersForReservation(reservationId: String) {
+        viewModelScope.launch(recordExceptionHandler) {
+            submitPreQuestionAnswers(reservationId)
+        }
     }
 
     private fun requestOrderId(): Flow<String> {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -208,6 +208,10 @@
     <!-- 사전 질문 -->
     <string name="pre_questions_label">사전 질문</string>
     <string name="pre_question_placeholder">답변을 입력해주세요</string>
+    <string name="pre_question_edit_title">사전 질문 작성하기</string>
+    <string name="pre_question_create_button">작성하기</string>
+    <string name="pre_question_edit_button">수정하기</string>
+    <string name="pre_question_no_answer">작성한 내용이 없어요</string>
 
     <!-- 선물하기 -->
     <string name="gift_receiver_info">받는 분 정보</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -212,6 +212,7 @@
     <string name="pre_question_create_button">작성하기</string>
     <string name="pre_question_edit_button">수정하기</string>
     <string name="pre_question_no_answer">작성한 내용이 없어요</string>
+    <string name="pre_question_save_complete">사전 질문 작성을 완료했어요</string>
 
     <!-- 선물하기 -->
     <string name="gift_receiver_info">받는 분 정보</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -205,6 +205,10 @@
     <string name="order_agreement_privacy_offer">[필수] 개인정보 제 3자 정보 제공 동의</string>
     <string name="order_agreement_payment_agency">[필수] 결제대행 서비스 이용약관 동의</string>
 
+    <!-- 사전 질문 -->
+    <string name="pre_questions_label">사전 질문</string>
+    <string name="pre_question_placeholder">답변을 입력해주세요</string>
+
     <!-- 선물하기 -->
     <string name="gift_receiver_info">받는 분 정보</string>
     <string name="gift_sender_info">보내는 분 정보</string>


### PR DESCRIPTION
## Issue
- close #436

## 작업 내용
- ShowItemV2 컴포넌트 추가 및 여러 화면에 적용
- 예매/결제 화면에 사전질문 작성 기능 추가
- 예매 상세 화면에 사전질문 조회/수정 기능 추가
- Lifecycle 이벤트 처리 공통 Composable 추가 (OnResume, OnStart)

<img width="530" height="1104" alt="image" src="https://github.com/user-attachments/assets/813941b8-92d9-4d72-b77c-11df2fb6309b" />

<img width="533" height="1108" alt="image" src="https://github.com/user-attachments/assets/dff3eda5-0900-4142-aacf-cd5a6cc77d58" />

<img width="528" height="1105" alt="image" src="https://github.com/user-attachments/assets/d696e542-0173-45ba-9053-2652c2679792" />
