### PR TITLE
refactor: 사전 질문 API 스펙 변경 대응

### DIFF
--- a/data/src/main/java/com/nexters/boolti/data/network/response/PreQuestionAnswerResponse.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/response/PreQuestionAnswerResponse.kt
@@ -14,9 +14,9 @@ internal data class PreQuestionAnswerDetailResponse(
 internal data class PreQuestionAnswerItemResponse(
     val preQuestionId: Long,
     val question: String,
-    val description: String?,
+    val description: String,
     val isRequired: Boolean,
-    val answer: String?,
+    val answer: String,
     val createdAt: String?,
     val modifiedAt: String?,
 )
@@ -24,9 +24,9 @@ internal data class PreQuestionAnswerItemResponse(
 internal fun PreQuestionAnswerItemResponse.toDomain() = PreQuestionAnswer(
     preQuestionId = preQuestionId,
     question = question,
-    description = description.orEmpty(),
+    description = description,
     isRequired = isRequired,
-    answer = answer.orEmpty(),
+    answer = answer,
 )
 
 internal fun List<PreQuestionAnswerItemResponse>.toDomains() = map { it.toDomain() }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditViewModel.kt
@@ -133,7 +133,6 @@ class PreQuestionEditViewModel @Inject constructor(
     private fun submitAnswers() {
         val state = uiState.value
         val answerRequests = state.answers
-            .filter { (_, answer) -> answer.isNotBlank() }
             .map { (questionId, answer) ->
                 PreQuestionAnswerRequest(
                     preQuestionId = questionId,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/TicketingViewModel.kt
@@ -235,15 +235,12 @@ class TicketingViewModel @Inject constructor(
         if (state.preQuestions.isEmpty()) return
 
         val answers = state.preQuestionAnswers
-            .filter { (_, answer) -> answer.isNotBlank() }
             .map { (questionId, answer) ->
                 PreQuestionAnswerRequest(
                     preQuestionId = questionId,
                     answer = answer,
                 )
             }
-
-        if (answers.isEmpty()) return
 
         val request = SubmitPreQuestionAnswersRequest(
             reservationId = reservationId,


### PR DESCRIPTION
## Issue


## 작업 내용
- 사전 질문 응답 DTO의 `description`, `answer` 필드를 non-null로 변경 (미응답은 빈 문자열)
- 답변 제출 시 `isNotBlank()` 필터링 제거하여 텍스트필드 입력값을 그대로 전송