### PR TITLE
fix: 사전 질문 UI/UX 개선 및 환불 화면 패딩 조정

### DIFF
--- a/data/src/main/java/com/nexters/boolti/data/network/response/TicketGroupDto.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/response/TicketGroupDto.kt
@@ -97,6 +97,8 @@ internal data class TicketGroupDto(
     val userId: String? = null,
     @SerialName("giftUuid")
     val giftUuid: String? = null,
+    @SerialName("salesEndTime")
+    val salesEndTime: String? = null,
 ) {
     fun toDomain(): TicketGroup = TicketGroup(
         userId = userId ?: "",
@@ -119,6 +121,7 @@ internal data class TicketGroupDto(
         } ?: emptyList(),
         isGift = giftUuid != null,
         giftUuid = giftUuid,
+        salesEndTime = salesEndTime?.toLocalDateTime(),
     )
 
     @Serializable

--- a/domain/src/main/java/com/nexters/boolti/domain/model/Ticket.kt
+++ b/domain/src/main/java/com/nexters/boolti/domain/model/Ticket.kt
@@ -33,6 +33,7 @@ data class TicketGroup(
     val tickets: List<Ticket> = emptyList(),
     val giftUuid: String? = null,
     val isGift: Boolean = false,
+    val salesEndTime: LocalDateTime? = null,
 ) {
     data class Ticket(
         val ticketId: String = "",

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditScreen.kt
@@ -126,6 +126,7 @@ private fun PreQuestionEditItem(
     Column(modifier = modifier) {
         Row {
             Text(
+                modifier = Modifier.weight(1f, fill = false),
                 text = question.question,
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/prequestionedit/PreQuestionEditViewModel.kt
@@ -116,6 +116,8 @@ class PreQuestionEditViewModel @Inject constructor(
         questions: ImmutableList<PreQuestionAnswer>,
         answers: ImmutableMap<Long, String>,
     ): Boolean {
+        val hasChanges = initialAnswers != null && initialAnswers != answers
+
         val requiredAnswered = questions
             .filter { it.isRequired }
             .all { question ->
@@ -127,7 +129,7 @@ class PreQuestionEditViewModel @Inject constructor(
             it.unicodeLength() > PreQuestionEditUiState.MAX_ANSWER_LENGTH
         }
 
-        return requiredAnswered && noInvalidAnswers
+        return hasChanges && requiredAnswered && noInvalidAnswers
     }
 
     private fun submitAnswers() {

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/refund/RefundInfoPage.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/refund/RefundInfoPage.kt
@@ -78,7 +78,7 @@ fun RefundInfoPage(
             titleStyle = point2,
         )
         Section(
-            modifier = Modifier.padding(top = 12.dp),
+            modifier = Modifier.padding(top = 20.dp),
             title = stringResource(id = R.string.refund_information),
             expandable = false,
         ) {

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticket/detail/TicketDetailViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticket/detail/TicketDetailViewModel.kt
@@ -63,7 +63,14 @@ class TicketDetailViewModel @Inject constructor(
                     }
                 }
                 .onEach { ticketGroup ->
-                    _uiState.update { it.copy(ticketGroup = ticketGroup) }
+                    _uiState.update {
+                        it.copy(
+                            ticketGroup = ticketGroup,
+                            canEditPreQuestion = ticketGroup.salesEndTime?.let { salesEnd ->
+                                salesEnd >= LocalDateTime.now()
+                            } ?: false,
+                        )
+                    }
                 }
                 .launchIn(viewModelScope + recordExceptionHandler)
 
@@ -71,7 +78,6 @@ class TicketDetailViewModel @Inject constructor(
                 _uiState.update { it.copy(refundPolicy = refundPolicy) }
             }.launchIn(viewModelScope + recordExceptionHandler)
 
-            fetchReservationDetail()
             fetchPreQuestionAnswers()
         }
     }
@@ -80,19 +86,6 @@ class TicketDetailViewModel @Inject constructor(
 
     fun refreshPreQuestionAnswers() {
         fetchPreQuestionAnswers()
-    }
-
-    private fun fetchReservationDetail() {
-        reservationRepository.findReservationById(ticketId)
-            .onEach { detail ->
-                _uiState.update {
-                    it.copy(canEditPreQuestion = detail.salesEndDateTime >= LocalDateTime.now())
-                }
-            }
-            .catch { e ->
-                Timber.e(e, "Failed to fetch reservation detail for salesEndDateTime")
-            }
-            .launchIn(viewModelScope + recordExceptionHandler)
     }
 
     private fun fetchPreQuestionAnswers() {

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/PreQuestionsSection.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/ticketing/PreQuestionsSection.kt
@@ -12,16 +12,15 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.nexters.boolti.domain.model.PreQuestion
 import com.nexters.boolti.presentation.R
+import com.nexters.boolti.presentation.component.BTTextField
 import com.nexters.boolti.presentation.extension.unicodeLength
+import com.nexters.boolti.presentation.theme.Grey50
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
-import com.nexters.boolti.presentation.component.BTTextField
-import com.nexters.boolti.presentation.theme.Grey50
 
 @Composable
 internal fun PreQuestionsSection(
@@ -62,6 +61,7 @@ private fun PreQuestionItem(
     Column(modifier = modifier) {
         Row {
             Text(
+                modifier = Modifier.weight(1f, fill = false),
                 text = question.question,
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -94,7 +94,11 @@ private fun PreQuestionItem(
             placeholder = stringResource(R.string.pre_question_placeholder),
             singleLine = false,
             isError = isError,
-            bottomEndText = stringResource(R.string.input_limit, answer.unicodeLength(), TicketingState.MAX_ANSWER_LENGTH),
+            bottomEndText = stringResource(
+                R.string.input_limit,
+                answer.unicodeLength(),
+                TicketingState.MAX_ANSWER_LENGTH
+            ),
             supportingText = if (isError) {
                 stringResource(R.string.input_upper_limit_text, TicketingState.MAX_ANSWER_LENGTH)
             } else null,


### PR DESCRIPTION
## Issue


## 작업 내용
- 사전 질문 수정 화면 완료 버튼 활성화 조건에 변경 감지 추가 (기존 답변과 달라진 경우에만 활성화)
- 사전 질문 제목이 길어도 필수 표시(*)가 화면을 벗어나지 않도록 수정
- 환불 정보 섹션 상단 패딩 조정 (12dp → 20dp)
- [티켓 상세 API 응답의 salesEndTime 활용하여 별도 예약 조회 제거](https://github.com/Nexters/Boolti/pull/452/changes/b9ba50e1d4780a141f7e765c09ea0922939cc080)

<img width="640" height="317" alt="image" src="https://github.com/user-attachments/assets/9ea21d54-1cc2-4d38-8672-5092417246a6" />

