### PR TITLE
[QA] 필수 답변 별표 위치 수정

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/PreQuestionAnswerItem.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/PreQuestionAnswerItem.kt
@@ -46,6 +46,7 @@ fun PreQuestionAnswerItem(
     ) {
         Row {
             Text(
+                modifier = Modifier.weight(1f, fill = false),
                 text = answer.question,
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,


### PR DESCRIPTION
## 작업 내용
- 결제 내역 상세 화면/티켓 상세 화면의 사전 질문 답변 영역에서 필수 답변 별표(*) 위치 수정
- 질문 텍스트에 weight를 적용해 별표가 우측 패딩을 벗어나지 않도록 정렬 수정

## 관련 이슈
- Closes #454