### PR TITLE
[Fix] 취소된 티켓 결제내역에서 사전질문 편집 비활성화

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/PreQuestionAnswersSection.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/PreQuestionAnswersSection.kt
@@ -10,10 +10,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.nexters.boolti.domain.model.PreQuestionAnswer
+import com.nexters.boolti.domain.model.ReservationState
 import com.nexters.boolti.presentation.R
 import com.nexters.boolti.presentation.component.MainButton
 import com.nexters.boolti.presentation.component.MainButtonDefaults
-import com.nexters.boolti.presentation.component.PreQuestionAnswerItem
 import com.nexters.boolti.presentation.component.PreQuestionAnswerItem
 import com.nexters.boolti.presentation.theme.Grey70
 import kotlinx.collections.immutable.ImmutableList
@@ -23,13 +23,15 @@ import java.time.LocalDateTime
 internal fun PreQuestionAnswersSection(
     answers: ImmutableList<PreQuestionAnswer>,
     salesEndDateTime: LocalDateTime,
+    reservationState: ReservationState,
     onNavigateToEdit: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (answers.isEmpty()) return
 
     val hasAnswers = answers.any { it.answer.isNotBlank() }
-    val canEdit = salesEndDateTime >= LocalDateTime.now()
+    val canEdit = salesEndDateTime >= LocalDateTime.now() &&
+        reservationState !in listOf(ReservationState.CANCELED, ReservationState.REFUNDED)
 
     Section(
         modifier = modifier,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/PreQuestionAnswersSection.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/PreQuestionAnswersSection.kt
@@ -10,28 +10,23 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.nexters.boolti.domain.model.PreQuestionAnswer
-import com.nexters.boolti.domain.model.ReservationState
 import com.nexters.boolti.presentation.R
 import com.nexters.boolti.presentation.component.MainButton
 import com.nexters.boolti.presentation.component.MainButtonDefaults
 import com.nexters.boolti.presentation.component.PreQuestionAnswerItem
 import com.nexters.boolti.presentation.theme.Grey70
 import kotlinx.collections.immutable.ImmutableList
-import java.time.LocalDateTime
 
 @Composable
 internal fun PreQuestionAnswersSection(
     answers: ImmutableList<PreQuestionAnswer>,
-    salesEndDateTime: LocalDateTime,
-    reservationState: ReservationState,
+    canEdit: Boolean,
     onNavigateToEdit: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (answers.isEmpty()) return
 
     val hasAnswers = answers.any { it.answer.isNotBlank() }
-    val canEdit = salesEndDateTime >= LocalDateTime.now() &&
-        reservationState !in listOf(ReservationState.CANCELED, ReservationState.REFUNDED)
 
     Section(
         modifier = modifier,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailScreen.kt
@@ -140,12 +140,14 @@ fun ReservationDetailScreen(
             }
             TicketInfo(reservation = state.reservation)
             PaymentInfo(reservation = state.reservation)
-            PreQuestionAnswersSection(
-                modifier = Modifier.padding(top = 12.dp),
-                answers = preQuestionAnswers,
-                canEdit = state.canEditPreQuestions,
-                onNavigateToEdit = { navigateToPreQuestionEdit(state.reservation.id) },
-            )
+            if (state.canShowPreQuestions) {
+                PreQuestionAnswersSection(
+                    modifier = Modifier.padding(top = 12.dp),
+                    answers = preQuestionAnswers,
+                    canEdit = state.canEditPreQuestions,
+                    onNavigateToEdit = { navigateToPreQuestionEdit(state.reservation.id) },
+                )
+            }
             if (state.reservation.reservationState in listOf(
                     ReservationState.REFUNDED,
                     ReservationState.CANCELED

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailScreen.kt
@@ -143,8 +143,7 @@ fun ReservationDetailScreen(
             PreQuestionAnswersSection(
                 modifier = Modifier.padding(top = 12.dp),
                 answers = preQuestionAnswers,
-                salesEndDateTime = state.reservation.salesEndDateTime,
-                reservationState = state.reservation.reservationState,
+                canEdit = state.canEditPreQuestions,
                 onNavigateToEdit = { navigateToPreQuestionEdit(state.reservation.id) },
             )
             if (state.reservation.reservationState in listOf(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailScreen.kt
@@ -144,6 +144,7 @@ fun ReservationDetailScreen(
                 modifier = Modifier.padding(top = 12.dp),
                 answers = preQuestionAnswers,
                 salesEndDateTime = state.reservation.salesEndDateTime,
+                reservationState = state.reservation.reservationState,
                 onNavigateToEdit = { navigateToPreQuestionEdit(state.reservation.id) },
             )
             if (state.reservation.reservationState in listOf(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailUiState.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailUiState.kt
@@ -9,6 +9,7 @@ sealed interface ReservationDetailUiState {
 
     data class Success(
         val reservation: ReservationDetail,
+        val canShowPreQuestions: Boolean,
         val canEditPreQuestions: Boolean,
     ) : ReservationDetailUiState
 
@@ -17,9 +18,13 @@ sealed interface ReservationDetailUiState {
     ) : ReservationDetailUiState
 }
 
-internal fun ReservationDetail.canEditPreQuestions(now: LocalDateTime = LocalDateTime.now()): Boolean {
-    return salesEndDateTime >= now && reservationState !in listOf(
+internal fun ReservationDetail.canShowPreQuestions(): Boolean {
+    return reservationState !in listOf(
         ReservationState.CANCELED,
         ReservationState.REFUNDED,
     )
+}
+
+internal fun ReservationDetail.canEditPreQuestions(now: LocalDateTime = LocalDateTime.now()): Boolean {
+    return canShowPreQuestions() && salesEndDateTime >= now
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailUiState.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailUiState.kt
@@ -1,15 +1,25 @@
 package com.nexters.boolti.presentation.screen.reservationdetail
 
 import com.nexters.boolti.domain.model.ReservationDetail
+import com.nexters.boolti.domain.model.ReservationState
+import java.time.LocalDateTime
 
 sealed interface ReservationDetailUiState {
     data object Loading : ReservationDetailUiState
 
     data class Success(
         val reservation: ReservationDetail,
+        val canEditPreQuestions: Boolean,
     ) : ReservationDetailUiState
 
     data class Error(
         val message: String = ""
     ) : ReservationDetailUiState
+}
+
+internal fun ReservationDetail.canEditPreQuestions(now: LocalDateTime = LocalDateTime.now()): Boolean {
+    return salesEndDateTime >= now && reservationState !in listOf(
+        ReservationState.CANCELED,
+        ReservationState.REFUNDED,
+    )
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailViewModel.kt
@@ -62,7 +62,12 @@ class ReservationDetailViewModel @Inject constructor(
                 _uiState.update { ReservationDetailUiState.Loading }
             }
             .onEach { reservation ->
-                _uiState.update { ReservationDetailUiState.Success(reservation) }
+                _uiState.update {
+                    ReservationDetailUiState.Success(
+                        reservation = reservation,
+                        canEditPreQuestions = reservation.canEditPreQuestions(),
+                    )
+                }
                 fetchPreQuestionAnswers()
             }
             .catch {

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/reservationdetail/ReservationDetailViewModel.kt
@@ -62,13 +62,19 @@ class ReservationDetailViewModel @Inject constructor(
                 _uiState.update { ReservationDetailUiState.Loading }
             }
             .onEach { reservation ->
+                val canShowPreQuestions = reservation.canShowPreQuestions()
                 _uiState.update {
                     ReservationDetailUiState.Success(
                         reservation = reservation,
+                        canShowPreQuestions = canShowPreQuestions,
                         canEditPreQuestions = reservation.canEditPreQuestions(),
                     )
                 }
-                fetchPreQuestionAnswers()
+                if (canShowPreQuestions) {
+                    fetchPreQuestionAnswers()
+                } else {
+                    _preQuestionAnswers.value = persistentListOf()
+                }
             }
             .catch {
                 _uiState.update { ReservationDetailUiState.Error() }
@@ -78,6 +84,11 @@ class ReservationDetailViewModel @Inject constructor(
     }
 
     fun refreshPreQuestionAnswers() {
+        val state = _uiState.value as? ReservationDetailUiState.Success ?: return
+        if (!state.canShowPreQuestions) {
+            _preQuestionAnswers.value = persistentListOf()
+            return
+        }
         fetchPreQuestionAnswers()
     }
 


### PR DESCRIPTION
## 작업 내용
- 결제내역 상세 화면의 사전질문 편집 가능 조건에 예약 상태를 반영
- 판매 종료 전이라도 취소(CANCELED), 환불(REFUNDED) 상태인 경우 사전질문 작성/수정 버튼이 노출되지 않도록 수정
- 서버 정책과 앱 UI 정책이 일치하도록 정리

## 관련 이슈
- Closes #459