### PR TITLE
ci: 정책 변경 감지 시 boolti-docs로 dispatch 추가

### DIFF
--- a/.github/workflows/notify-policy-changes.yml
+++ b/.github/workflows/notify-policy-changes.yml
@@ -1,0 +1,48 @@
+name: Notify Policy Changes
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'domain/src/**'
+      - 'data/src/**'
+      - 'presentation/src/**'
+
+jobs:
+  dispatch:
+    name: Dispatch to boolti-docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Collect changed files
+        id: changes
+        run: |
+          FILES=$(git diff --name-only HEAD~1 HEAD -- \
+            'domain/src/**' \
+            'data/src/**' \
+            'presentation/src/**')
+          COUNT=$(echo "$FILES" | wc -l | tr -d ' ')
+          LIST=$(echo "$FILES" | head -10 | sed 's/^/- /')
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          {
+            echo "list<<EOF"
+            echo "$LIST"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Dispatch to boolti-docs
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+          repository: ryanproback/boolti-docs
+          event-type: policy-changed
+          client-payload: |
+            {
+              "source_repo": "Nexters/Boolti",
+              "commit_sha": "${{ github.sha }}",
+              "file_count": "${{ steps.changes.outputs.count }}",
+              "changed_files": "${{ steps.changes.outputs.list }}"
+            }


### PR DESCRIPTION
## Summary
- main 머지 시 정책 관련 파일 변경을 감지하여 boolti-docs로 repository_dispatch 전송
- 감시 경로: `domain/src/**`, `data/src/**`, `presentation/src/**`
- Discord 알림으로 변경 내용 공유

## 관련 레포
- 수신측: ryanproback/boolti-docs
- 동일 워크플로우: boolti-api, boolti-web, Boolti-iOS