### PR TITLE
fix: escape newlines in changed_files JSON payload

### DIFF
--- a/.github/workflows/notify-policy-changes.yml
+++ b/.github/workflows/notify-policy-changes.yml
@@ -25,13 +25,10 @@ jobs:
             'data/src/**' \
             'presentation/src/**')
           COUNT=$(echo "$FILES" | wc -l | tr -d ' ')
-          LIST=$(echo "$FILES" | head -10 | sed 's/^/- /')
+          LIST=$(echo "$FILES" | head -10 | sed 's/^/- /' | jq -Rs '.')
+          LIST=${LIST:1:-1}  # strip outer quotes from jq output
           echo "count=$COUNT" >> $GITHUB_OUTPUT
-          {
-            echo "list<<EOF"
-            echo "$LIST"
-            echo "EOF"
-          } >> $GITHUB_OUTPUT
+          echo "list=$LIST" >> $GITHUB_OUTPUT
 
       - name: Dispatch to boolti-docs
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
## Summary

- `changed_files` 값에 raw newline이 포함되어 `Bad control character in string literal in JSON` 에러가 발생하는 버그 수정
- `jq -Rs '.'`로 문자열을 JSON-safe하게 이스케이프 처리하고, heredoc 대신 단일 라인 output으로 변경
- boolti-api에서 동일한 이슈를 동일한 패턴으로 수정한 것과 같은 방식 적용

## Changes

`LIST` 변수 생성 시 `jq -Rs '.'`를 파이프라인에 추가하여 newline을 `\n`으로 이스케이프하고, heredoc 기반 multiline output 대신 단일 라인 `echo "list=$LIST"`로 변경.

## Test plan

- [ ] `domain/src/`, `data/src/`, `presentation/src/` 하위 파일 변경 후 main에 push하여 워크플로우 트리거
- [ ] boolti-docs repo에 `repository_dispatch` 이벤트가 유효한 JSON payload로 전달되는지 확인