### PR TITLE
[Boolti-477] GitHub Actions Gradle 빌드 캐시 추가

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -10,16 +10,19 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: set up JDK 17
-        uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '17'
 
-      - name: set up Android SDK
-        uses: android-actions/setup-android@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
## Issue
- Closes #477

## 작업 내용
- `gradle/actions/setup-gradle@v4` 추가로 Gradle 홈·deps·wrapper 캐시 적용
- `checkout`, `setup-java`, `setup-android` 최신 메이저 버전으로 업데이트

## 리뷰 포인트
- 첫 실행에선 캐시 미스로 빌드 시간이 동일하고, 두 번째 실행부터 단축 효과가 나타남
- PR에선 read-only, `develop` 머지 후 write 캐시 생성 — `setup-gradle@v4` 기본 동작