### PR TITLE
[Boolti-478] GitHub Actions에 APK 빌드 검증 추가

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -37,6 +37,9 @@ jobs:
           echo "$GOOGLE_SERVICES" | base64 -d > ./app/google-services.json
           ./gradlew test --stacktrace
 
+      - name: Build debug APK
+        run: ./gradlew assembleDebug --stacktrace
+
       - name: Publish Test Results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
## Issue
- Closes #478

## 작업 내용
- PR CI에 `./gradlew assembleDebug` step 추가로 APK 빌드 검증

## 리뷰 포인트
- 테스트 실패 시 빌드 step은 실행되지 않음(기본 `if: success()`). 테스트·빌드를 항상 둘 다 실행하려면 별도 조정 필요