### PR TITLE
[Boolti-473] PR 마일스톤 필수 액션 추가

### DIFF
--- a/.github/workflows/pr-milestone-required.yml
+++ b/.github/workflows/pr-milestone-required.yml
@@ -1,0 +1,30 @@
+name: PR Milestone Required
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - milestoned
+      - demilestoned
+      - ready_for_review
+
+jobs:
+  check-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify milestone is set
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const milestone = context.payload.pull_request.milestone;
+            if (!milestone) {
+              core.setFailed(
+                "이 PR에는 마일스톤이 지정되지 않았습니다. " +
+                "현재 앱 버전 마일스톤 또는 Tools 마일스톤을 지정한 뒤 다시 확인하세요."
+              );
+            } else {
+              core.info(`Milestone: ${milestone.title}`);
+            }


### PR DESCRIPTION
## Issue
- Closes #473

## 작업 내용
- PR에 마일스톤이 없으면 CI 실패시키는 워크플로우 추가 (`actions/github-script@v7`)
- `milestoned`/`demilestoned` 이벤트 포함 → 마일스톤 지정 즉시 재검사

## 리뷰 포인트
- 이 액션이 머지된 직후부터 본 PR 포함 모든 open PR에 적용됨. 기존 열린 PR에 마일스톤이 없으면 red가 뜨니 일괄 점검 필요