### PR TITLE
[Boolti-481] Secret 유출 방지 TruffleHog 스캔 추가

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,26 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified


### PR DESCRIPTION
## Issue
- Closes #481

## 작업 내용
- PR diff에 검증된 API 키·토큰이 있으면 실패시키는 `secret-scan.yml` 추가
- `trufflesecurity/trufflehog@main` + `--only-verified` 옵션으로 live secret만 차단

## 리뷰 포인트
- `@main` 핀은 공식 문서 권장 방식이지만 SHA/tag 핀이 더 안전. 팀 정책에 따라 조정 가능
- `--only-verified`는 외부 서비스에 검증 요청을 보내므로 network call 발생 (민감하지 않음)