### PR TITLE
[Boolti-475] data 레이어 runCatching 안티패턴 검증 액션 추가

### DIFF
--- a/.github/workflows/anti-pattern-check.yml
+++ b/.github/workflows/anti-pattern-check.yml
@@ -1,0 +1,49 @@
+name: Anti-Pattern Check
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - 'data/src/main/**/*.kt'
+      - '.github/workflows/anti-pattern-check.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: anti-pattern-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  run-catching:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect runCatching additions in data layer
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          violations=$(git diff "$BASE_SHA"..."$HEAD_SHA" -- 'data/src/main/**/*.kt' \
+            | grep -E '^\+[^+].*\brunCatching\b' \
+            | grep -v 'suspendRunCatching' \
+            || true)
+
+          if [ -z "$violations" ]; then
+            echo "✅ data 레이어에 추가된 runCatching이 없습니다."
+            exit 0
+          fi
+
+          echo "::error::data 레이어에 runCatching이 추가되었습니다. suspend 함수 내부에서는 suspendRunCatching (domain/util/Kotlin.kt)을 사용하세요."
+          echo ""
+          echo "위반 라인:"
+          echo "$violations"
+          exit 1

--- a/.github/workflows/anti-pattern-check.yml
+++ b/.github/workflows/anti-pattern-check.yml
@@ -33,7 +33,9 @@ jobs:
           set -euo pipefail
 
           violations=$(git diff "$BASE_SHA"..."$HEAD_SHA" -- 'data/src/main/**/*.kt' \
-            | grep -E '^\+[^+].*\brunCatching\b' \
+            | grep -E '^\+[^+]' \
+            | grep -v -E '^\+[[:space:]]*(//|\*|/\*)' \
+            | grep -E '\brunCatching\b' \
             | grep -v 'suspendRunCatching' \
             || true)
 


### PR DESCRIPTION
## Issue
- Closes #475

## 작업 내용
- `anti-pattern-check.yml`: PR diff에서 `data/src/main/**/*.kt`에 새로 추가된 `runCatching` 사용을 탐지해 실패
- `paths:` 필터로 데이터 레이어 PR에서만 트리거, 3분 timeout
- 주석 라인(`//`, `*`, `/*`) 제외 필터로 false positive 방지
- fork PR 가드, concurrency 포함

## 리뷰 포인트
- 추가된 라인만 검사 (기존 9개 파일의 `runCatching`은 건드리지 않음). 별도 이관 작업은 후속 PR
- regex 기반 한계로 같은 줄에 `runCatching` 추가 + `suspendRunCatching` 참조가 섞이면 놓치는 희귀 케이스 있음
- `domain/util/Kotlin.kt:6`의 `suspendRunCatching`을 사용하도록 에러 메시지에서 안내