### PR TITLE
[Boolti-480] 릴리즈 버전 검증 액션 추가

### DIFF
--- a/.github/workflows/release-version-check.yml
+++ b/.github/workflows/release-version-check.yml
@@ -1,0 +1,88 @@
+name: Release Version Check
+
+on:
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-version-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify versionCode and versionName
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          extract() {
+            local source="$1"
+            local key="$2"
+            local content
+            if [ "$source" = "HEAD" ]; then
+              content=$(cat gradle/libs.versions.toml)
+            else
+              content=$(git show "$source":gradle/libs.versions.toml)
+            fi
+            awk -F '"' -v k="$key" '$0 ~ "^"k" = \"" { print $2; exit }' <<< "$content"
+          }
+
+          current_code=$(extract HEAD versionCode)
+          current_name=$(extract HEAD versionName)
+          main_code=$(extract origin/main versionCode)
+          main_name=$(extract origin/main versionName)
+
+          branch_version="${HEAD_REF#release/}"
+
+          echo "Branch: $HEAD_REF (version: $branch_version)"
+          echo "versionCode: $current_code (main: $main_code)"
+          echo "versionName: $current_name (main: $main_name)"
+
+          errors=0
+
+          if ! [ "$current_code" -gt "$main_code" ] 2>/dev/null; then
+            echo "::error::versionCode($current_code) must be greater than main($main_code)."
+            errors=$((errors + 1))
+          fi
+
+          if [ "$current_name" != "$branch_version" ]; then
+            echo "::error::versionName($current_name) must equal branch suffix ($branch_version)."
+            errors=$((errors + 1))
+          fi
+
+          if [ "$current_name" = "$main_name" ]; then
+            echo "::error::versionName($current_name) must differ from main($main_name)."
+            errors=$((errors + 1))
+          else
+            highest=$(printf '%s\n%s\n' "$current_name" "$main_name" | sort -V | tail -1)
+            if [ "$highest" != "$current_name" ]; then
+              echo "::error::versionName($current_name) must be greater than main($main_name) per semver."
+              errors=$((errors + 1))
+            fi
+          fi
+
+          if [ "$errors" -gt 0 ]; then
+            exit 1
+          fi
+
+          echo "✅ release 버전 검증 통과"


### PR DESCRIPTION
## Issue
- Closes #480

## 작업 내용
- `release-version-check.yml`: `release/*` → `main` PR에서만 실행
- `gradle/libs.versions.toml`의 `versionCode`·`versionName`을 `HEAD`와 `origin/main`에서 추출해 세 가지 검증
  1. `versionCode` 정수 증가
  2. `versionName` == 브랜치 suffix (`release/1.15.0` → `1.15.0`)
  3. `versionName` > main 버전 (`sort -V` semver 비교)
- fork PR 가드, concurrency, 3분 timeout

## 리뷰 포인트
- `sort -V`는 GNU coreutils 전용 — ubuntu-latest 러너에서만 동작 보장
- Pre-release 버전을 쓸 경우 `-rc1` 대신 **틸드(`~rc1`)** 를 붙여야 함. `sort -V`는 strict semver와 달리 하이픈 suffix(`1.15.0-rc1`)를 정식 버전(`1.15.0`)보다 **높게** 판단해서 pre→release 승격 PR이 잘못 실패함. 틸드 suffix는 정식보다 **낮게** 판단(GNU/Debian 관례). 현재 팀은 pre-release를 쓰지 않으므로 당장 영향 없음