### PR TITLE
[Boolti-492] 공연 상세 탭 전환 시 WebView 재로딩 및 로그 과다 출력 개선

### DIFF
--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/BtWebView.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/BtWebView.kt
@@ -142,10 +142,9 @@ class BtWebChromeClient(
         filePathCallback: ValueCallback<Array<Uri>>?,
         fileChooserParams: FileChooserParams
     ): Boolean {
-        if (filePathCallback == null) return false
-        setFilePathCallback?.invoke(filePathCallback)
-
-        launchActivity?.invoke()
+        if (filePathCallback == null || setFilePathCallback == null || launchActivity == null) return false
+        setFilePathCallback.invoke(filePathCallback)
+        launchActivity.invoke()
 
         return true
     }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/BtWebView.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/BtWebView.kt
@@ -56,8 +56,8 @@ class BtWebView @JvmOverloads constructor(
     }
 
     fun setWebChromeClient(
-        launchActivity: () -> Unit,
-        setFilePathCallback: (ValueCallback<Array<Uri>>) -> Unit,
+        launchActivity: (() -> Unit)? = null,
+        setFilePathCallback: ((ValueCallback<Array<Uri>>) -> Unit)? = null,
     ) {
         webChromeClient = BtWebChromeClient(
             launchActivity = launchActivity,
@@ -128,8 +128,8 @@ class BtWebViewClient(
 }
 
 class BtWebChromeClient(
-    private val launchActivity: () -> Unit,
-    private val setFilePathCallback: (ValueCallback<Array<Uri>>) -> Unit,
+    private val launchActivity: (() -> Unit)?,
+    private val setFilePathCallback: ((ValueCallback<Array<Uri>>) -> Unit)?,
     private val onProgressChanged: (Int) -> Unit = {},
 ) : WebChromeClient() {
     override fun onProgressChanged(view: WebView?, newProgress: Int) {
@@ -143,9 +143,9 @@ class BtWebChromeClient(
         fileChooserParams: FileChooserParams
     ): Boolean {
         if (filePathCallback == null) return false
-        setFilePathCallback(filePathCallback)
+        setFilePathCallback?.invoke(filePathCallback)
 
-        launchActivity()
+        launchActivity?.invoke()
 
         return true
     }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
@@ -753,7 +753,7 @@ private fun LazyListScope.ShowInfoTab(
     infoContentWebView: BtWebView,
 ) {
     item {
-        var isLoading by remember { mutableStateOf(true) }
+        var isLoading by remember { mutableStateOf(infoContentWebView.progress.value < 100) }
         val scope = rememberCoroutineScope()
 
         Box(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
@@ -283,8 +283,8 @@ fun ShowDetailScreen(
     val uriHandler = LocalUriHandler.current
     var redirectedInquiryUrl: String? by remember { mutableStateOf(null) }
     var intentToNavigateTo: Intent? by remember { mutableStateOf(null) }
-    val webView by remember {
-        mutableStateOf(BtWebView(preUriLoading = { url ->
+    val webView = remember {
+        BtWebView(preUriLoading = { url ->
             preUriLoading(
                 url = url,
                 context = context,
@@ -294,7 +294,7 @@ fun ShowDetailScreen(
         }, context = context).apply {
             loadUrl(url)
             setBackgroundColor(android.graphics.Color.TRANSPARENT)
-        })
+        }
     }
 
     LaunchedEffect(intentToNavigateTo) {

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
@@ -778,6 +778,7 @@ private fun LazyListScope.ShowInfoTab(
                         progress.onEach {
                             isLoading = it < 100
                         }.launchIn(scope)
+                        setWebChromeClient()
                     }
                 },
             )

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
@@ -283,7 +283,7 @@ fun ShowDetailScreen(
     val uriHandler = LocalUriHandler.current
     var redirectedInquiryUrl: String? by remember { mutableStateOf(null) }
     var intentToNavigateTo: Intent? by remember { mutableStateOf(null) }
-    val webView = remember {
+    val webView = remember(context, url) {
         BtWebView(preUriLoading = { url ->
             preUriLoading(
                 url = url,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.text.TextUtils
 import android.view.ViewGroup
+import android.webkit.WebView
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
@@ -273,6 +274,37 @@ fun ShowDetailScreen(
 
     val scope = rememberCoroutineScope()
     var showBottomSheet by remember { mutableStateOf<TicketBottomSheetType?>(null) }
+    val host = if (BuildConfig.DEBUG) "dev.preview.boolti.in" else "preview.boolti.in"
+    val url = "https://${host}/show/${showDetail.id}/info"
+    // ex. tel:010-1010-1101
+    val telSchemes = listOf("tel", "telprompt")
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+    var redirectedInquiryUrl: String? by remember { mutableStateOf(null) }
+    var intentToNavigateTo: Intent? by remember { mutableStateOf(null) }
+    val webView by remember {
+        mutableStateOf(BtWebView(preUriLoading = { url ->
+            preUriLoading(
+                url = url,
+                context = context,
+                uriHandler = uriHandler,
+                navigateWithUrl = { url -> redirectedInquiryUrl = url },
+                navigateWithIntent = { intent -> intentToNavigateTo = intent })
+        }, context = context).apply {
+            loadUrl(url)
+            setBackgroundColor(android.graphics.Color.TRANSPARENT)
+        })
+    }
+
+    LaunchedEffect(intentToNavigateTo) {
+        if (intentToNavigateTo != null && !shouldShowNaverMapDialog) {
+            if (intentToNavigateTo?.`package` == "com.nhn.android.nmap") {
+                trackNaverMap()
+            }
+            context.startActivity(intentToNavigateTo)
+            intentToNavigateTo = null
+        }
+    }
 
     Box(
         modifier = modifier.fillMaxSize(),
@@ -314,9 +346,7 @@ fun ShowDetailScreen(
 
             when (selectedTab) {
                 0 -> ShowInfoTab(
-                    showId = showDetail.id,
-                    shouldShowNaverMapDialog = shouldShowNaverMapDialog,
-                    doNotShowNaverMapDialog = doNotShowNaverMapDialog
+                    infoContentWebView = webView,
                 )
 
                 1 -> CastTab(
@@ -379,6 +409,17 @@ fun ShowDetailScreen(
                 deadlineDateTime = showDetail.salesEndDateTime!!,
             )
         }
+
+        redirectedInquiryUrl?.let { url ->
+            val contact = url.filterToPhoneNumber()
+            val isPhone = URI(url).scheme in telSchemes
+
+            InquiryBottomSheet(
+                isTelephone = isPhone,
+                onDismissRequest = { redirectedInquiryUrl = null },
+                contact = contact
+            )
+        }
     }
 
     showBottomSheet?.let { type ->
@@ -406,6 +447,43 @@ fun ShowDetailScreen(
                 showBottomSheet = null
             }
         )
+    }
+
+    if (intentToNavigateTo != null && shouldShowNaverMapDialog) {
+        BTDialog(
+            onDismiss = {
+                intentToNavigateTo = null
+            },
+            positiveButtonLabel = stringResource(R.string.show_navigate_to_nmap),
+            onClickPositiveButton = {
+                if (intentToNavigateTo?.`package` == "com.nhn.android.nmap") {
+                    trackNaverMap()
+                }
+                context.startActivity(intentToNavigateTo)
+                doNotShowNaverMapDialog()
+                intentToNavigateTo = null
+            }
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = stringResource(R.string.show_naver_map_dialog_title),
+                    color = Grey15,
+                    style = MaterialTheme.typography.titleLarge,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    modifier = Modifier.padding(
+                        top = 4.dp
+                    ),
+                    text = stringResource(R.string.show_naver_map_dialog_content),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Grey50,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
     }
 }
 
@@ -671,43 +749,9 @@ private fun ContentTab(
 @SuppressLint("SetJavaScriptEnabled")
 @Suppress("FunctionName")
 private fun LazyListScope.ShowInfoTab(
-    showId: String,
-    shouldShowNaverMapDialog: Boolean,
-    doNotShowNaverMapDialog: () -> Unit,
+    infoContentWebView: WebView,
 ) {
     item {
-        var redirectedInquiryUrl: String? by remember { mutableStateOf(null) }
-        val host = if (BuildConfig.DEBUG) "dev.preview.boolti.in" else "preview.boolti.in"
-        val url = "https://${host}/show/${showId}/info"
-        val context = LocalContext.current
-        val uriHandler = LocalUriHandler.current
-        var intentToNavigateTo: Intent? by remember { mutableStateOf(null) }
-
-        LaunchedEffect(intentToNavigateTo) {
-            if (intentToNavigateTo != null && !shouldShowNaverMapDialog) {
-                if (intentToNavigateTo?.`package` == "com.nhn.android.nmap") {
-                    trackNaverMap()
-                }
-                context.startActivity(intentToNavigateTo)
-                intentToNavigateTo = null
-            }
-        }
-
-        // ex. tel:010-1010-1101
-        val telSchemes = listOf("tel", "telprompt")
-        val webView by remember {
-            mutableStateOf(BtWebView(preUriLoading = { url ->
-                preUriLoading(
-                    url = url,
-                    context = context,
-                    uriHandler = uriHandler,
-                    navigateWithUrl = { url -> redirectedInquiryUrl = url },
-                    navigateWithIntent = { intent -> intentToNavigateTo = intent })
-            }, context = context).apply {
-                loadUrl(url)
-                setBackgroundColor(android.graphics.Color.TRANSPARENT)
-            })
-        }
 
         Box(
             modifier = Modifier
@@ -720,7 +764,7 @@ private fun LazyListScope.ShowInfoTab(
             AndroidView(
                 modifier = Modifier.fillMaxWidth(),
                 factory = { context ->
-                    webView.apply {
+                    infoContentWebView.apply {
                         layoutParams = ViewGroup.LayoutParams(
                             ViewGroup.LayoutParams.MATCH_PARENT,
                             ViewGroup.LayoutParams.WRAP_CONTENT,
@@ -729,54 +773,6 @@ private fun LazyListScope.ShowInfoTab(
                     }
                 },
             )
-        }
-
-        redirectedInquiryUrl?.let { url ->
-            val contact = url.filterToPhoneNumber()
-            val isPhone = URI(url).scheme in telSchemes
-
-            InquiryBottomSheet(
-                isTelephone = isPhone,
-                onDismissRequest = { redirectedInquiryUrl = null },
-                contact = contact
-            )
-        }
-
-        if (intentToNavigateTo != null && shouldShowNaverMapDialog) {
-            BTDialog(
-                onDismiss = {
-                    intentToNavigateTo = null
-                },
-                positiveButtonLabel = stringResource(R.string.show_navigate_to_nmap),
-                onClickPositiveButton = {
-                    if (intentToNavigateTo?.`package` == "com.nhn.android.nmap") {
-                        trackNaverMap()
-                    }
-                    context.startActivity(intentToNavigateTo)
-                    doNotShowNaverMapDialog()
-                    intentToNavigateTo = null
-                }
-            ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        text = stringResource(R.string.show_naver_map_dialog_title),
-                        color = Grey15,
-                        style = MaterialTheme.typography.titleLarge,
-                        textAlign = TextAlign.Center,
-                    )
-                    Text(
-                        modifier = Modifier.padding(
-                            top = 4.dp
-                        ),
-                        text = stringResource(R.string.show_naver_map_dialog_content),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = Grey50,
-                        textAlign = TextAlign.Center,
-                    )
-                }
-            }
         }
     }
 

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.text.TextUtils
 import android.view.ViewGroup
-import android.webkit.WebView
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
@@ -124,6 +123,8 @@ import com.nexters.boolti.presentation.theme.point2
 import com.nexters.boolti.presentation.theme.point3
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.net.URI
@@ -749,18 +750,22 @@ private fun ContentTab(
 @SuppressLint("SetJavaScriptEnabled")
 @Suppress("FunctionName")
 private fun LazyListScope.ShowInfoTab(
-    infoContentWebView: WebView,
+    infoContentWebView: BtWebView,
 ) {
     item {
+        var isLoading by remember { mutableStateOf(true) }
+        val scope = rememberCoroutineScope()
 
         Box(
             modifier = Modifier
                 .heightIn(min = 96.dp)
                 .fillMaxWidth()
         ) {
-            BtCircularProgressIndicator(
-                modifier = Modifier.align(Alignment.Center)
-            )
+            if (isLoading) {
+                BtCircularProgressIndicator(
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
             AndroidView(
                 modifier = Modifier.fillMaxWidth(),
                 factory = { context ->
@@ -770,6 +775,9 @@ private fun LazyListScope.ShowInfoTab(
                             ViewGroup.LayoutParams.WRAP_CONTENT,
                         )
                         setOnLongClickListener { true }
+                        progress.onEach {
+                            isLoading = it < 100
+                        }.launchIn(scope)
                     }
                 },
             )

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
@@ -283,7 +283,7 @@ fun ShowDetailScreen(
     val uriHandler = LocalUriHandler.current
     var redirectedInquiryUrl: String? by remember { mutableStateOf(null) }
     var intentToNavigateTo: Intent? by remember { mutableStateOf(null) }
-    val webView = remember(context, url) {
+    val webView = remember(context) {
         BtWebView(preUriLoading = { url ->
             preUriLoading(
                 url = url,
@@ -292,9 +292,12 @@ fun ShowDetailScreen(
                 navigateWithUrl = { url -> redirectedInquiryUrl = url },
                 navigateWithIntent = { intent -> intentToNavigateTo = intent })
         }, context = context).apply {
-            loadUrl(url)
             setBackgroundColor(android.graphics.Color.TRANSPARENT)
         }
+    }
+
+    LaunchedEffect(webView, url) {
+        webView.loadUrl(url)
     }
 
     LaunchedEffect(intentToNavigateTo) {


### PR DESCRIPTION
## Issue
- Closes #492

## 작업 내용
- 공연 상세 탭 전환 시 `webView`를 `ShowDetailScreen` 스코프로 호이스팅해 탭 복귀 시 재로딩 방지
- `setRequestedFrameRate` 로그가 초당 240번 출력되던 문제 개선

### 개선 전

https://github.com/user-attachments/assets/0e80a126-9b2c-4a2b-a932-8db5eb8614cc

### 개선 후

https://github.com/user-attachments/assets/4b7acc43-6cec-42e6-a994-39abaedbd448



## 리뷰 포인트
- `redirectedInquiryUrl`, `intentToNavigateTo` 상태는 `ShowInfoTab` 내부에 유지하고, WebView 인스턴스만 끌어올려 생명주기를 분리

<img src="" width="300" />