### PR TITLE
fix: 공연 상세 탭 전환 시 WebView 포커스 크래시 핫픽스 (v1.14.2)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 minSdk = "28"
 targetSdk = "36"
-versionCode = "51"
-versionName = "1.14.1"
+versionCode = "52"
+versionName = "1.14.2"
 packageName = "com.nexters.boolti"
 compileSdk = "36"
 targetJvm = "17"

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/showdetail/ShowDetailScreen.kt
@@ -704,6 +704,8 @@ private fun LazyListScope.ShowInfoTab(
                     navigateWithUrl = { url -> redirectedInquiryUrl = url },
                     navigateWithIntent = { intent -> intentToNavigateTo = intent })
             }, context = context).apply {
+                isFocusable = false
+                isFocusableInTouchMode = false
                 loadUrl(url)
                 setBackgroundColor(android.graphics.Color.TRANSPARENT)
             })


### PR DESCRIPTION
## 작업 내용
- 공연 정보 탭의 미리보기 WebView `focusable` 해제로 크래시 차단
- 앱 버전 상향 (1.14.1 → 1.14.2, versionCode 51 → 52)

## 크래시 정보
- 증상: 공연 정보 탭에서 '내용 더 보기' 누른 뒤 출연진 탭으로 전환 시 크래시
- 예외: `IllegalStateException: LayoutNode should be attached to an owner`
- 원인: 포커스를 쥔 WebView가 컴포지션에서 제거될 때, 포커스 재할당이 LazyList 강제 재측정을 트리거 → detach 중인 노드 배치 시도

## 리뷰 포인트
- 미리보기 WebView는 읽기 전용이라 포커스 불필요 → `isFocusable`/`isFocusableInTouchMode = false`로 해결
- 공용 `BtWebView`(기본 `focusable=true`)는 미변경 → 입력 필요한 다른 웹뷰(브릿지·정책)엔 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)