### PR TITLE
[Boolti-501] 공연장 검색 결과 API 연동

### DIFF
--- a/data/src/main/java/com/nexters/boolti/data/datasource/SearchDataSource.kt
+++ b/data/src/main/java/com/nexters/boolti/data/datasource/SearchDataSource.kt
@@ -5,6 +5,7 @@ import com.nexters.boolti.data.network.response.toNewShowsAndRisingKeywords
 import com.nexters.boolti.data.network.response.toPagingData
 import com.nexters.boolti.domain.model.NewShowsAndRisingKeywords
 import com.nexters.boolti.domain.model.PagingData
+import com.nexters.boolti.domain.model.Place
 import com.nexters.boolti.domain.model.Show
 import com.nexters.boolti.domain.model.User
 import com.nexters.boolti.domain.model.map
@@ -32,6 +33,14 @@ internal class SearchDataSource @Inject constructor(
     ): PagingData<User.Others> = searchService.requestProfiles(keyword, page, size)
         .toPagingData()
         .map { it.toDomain() }
+
+    suspend fun getPlaces(
+        keyword: String,
+        page: Int,
+        size: Int,
+    ): PagingData<Place> = searchService.requestConcertHalls(keyword, page, size)
+        .toPagingData()
+        .map { it.toPlace() }
 
     suspend fun getAutoCompleteKeywords(
         keyword: String,

--- a/data/src/main/java/com/nexters/boolti/data/network/api/SearchService.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/api/SearchService.kt
@@ -1,6 +1,6 @@
 package com.nexters.boolti.data.network.api
 
-import com.nexters.boolti.data.network.response.ConcertHallResponse
+import com.nexters.boolti.data.network.response.PlaceResponse
 import com.nexters.boolti.data.network.response.MemberResponse
 import com.nexters.boolti.data.network.response.PagingResponse
 import com.nexters.boolti.data.network.response.SearchOverviewResponse
@@ -40,7 +40,7 @@ internal interface SearchService {
         page: Int,
         @Query("size")
         size: Int,
-    ): PagingResponse<ConcertHallResponse>
+    ): PagingResponse<PlaceResponse>
 
     @GET("/app/papi/v1/shows/autocomplete")
     suspend fun requestAutoCompleteKeywords(

--- a/data/src/main/java/com/nexters/boolti/data/network/api/SearchService.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/api/SearchService.kt
@@ -1,5 +1,6 @@
 package com.nexters.boolti.data.network.api
 
+import com.nexters.boolti.data.network.response.ConcertHallResponse
 import com.nexters.boolti.data.network.response.MemberResponse
 import com.nexters.boolti.data.network.response.PagingResponse
 import com.nexters.boolti.data.network.response.SearchOverviewResponse
@@ -30,6 +31,16 @@ internal interface SearchService {
         @Query("size")
         size: Int,
     ): PagingResponse<MemberResponse>
+
+    @GET("/app/papi/v1/concert-halls/search")
+    suspend fun requestConcertHalls(
+        @Query("keyword")
+        keyword: String,
+        @Query("page")
+        page: Int,
+        @Query("size")
+        size: Int,
+    ): PagingResponse<ConcertHallResponse>
 
     @GET("/app/papi/v1/shows/autocomplete")
     suspend fun requestAutoCompleteKeywords(

--- a/data/src/main/java/com/nexters/boolti/data/network/response/ConcertHallResponse.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/response/ConcertHallResponse.kt
@@ -1,0 +1,21 @@
+package com.nexters.boolti.data.network.response
+
+import com.nexters.boolti.domain.model.Place
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class ConcertHallResponse(
+    val id: Long = 0L,
+    val name: String = "",
+    val representativeImageUrl: String = "",
+    val streetAddress: String = "",
+    val detailAddress: String = "",
+) {
+    fun toPlace(): Place = Place(
+        id = id.toString(),
+        name = name,
+        streetAddress = streetAddress,
+        detailAddress = detailAddress,
+        thumbnailImage = representativeImageUrl,
+    )
+}

--- a/data/src/main/java/com/nexters/boolti/data/network/response/PlaceResponse.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/response/PlaceResponse.kt
@@ -4,7 +4,7 @@ import com.nexters.boolti.domain.model.Place
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ConcertHallResponse(
+internal data class PlaceResponse(
     val id: Long = 0L,
     val name: String = "",
     val representativeImageUrl: String = "",

--- a/data/src/main/java/com/nexters/boolti/data/network/response/PlaceResponse.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/response/PlaceResponse.kt
@@ -5,14 +5,14 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class PlaceResponse(
-    val id: Long = 0L,
-    val name: String = "",
-    val representativeImageUrl: String = "",
-    val streetAddress: String = "",
-    val detailAddress: String = "",
+    val id: String,
+    val name: String,
+    val representativeImageUrl: String,
+    val streetAddress: String,
+    val detailAddress: String,
 ) {
     fun toPlace(): Place = Place(
-        id = id.toString(),
+        id = id,
         name = name,
         streetAddress = streetAddress,
         detailAddress = detailAddress,

--- a/data/src/main/java/com/nexters/boolti/data/network/response/PlaceResponse.kt
+++ b/data/src/main/java/com/nexters/boolti/data/network/response/PlaceResponse.kt
@@ -14,8 +14,8 @@ internal data class PlaceResponse(
     fun toPlace(): Place = Place(
         id = id,
         name = name,
-        streetAddress = streetAddress,
-        detailAddress = detailAddress,
+        streetAddress = streetAddress.trim(),
+        detailAddress = detailAddress.trim(),
         thumbnailImage = representativeImageUrl,
     )
 }

--- a/data/src/main/java/com/nexters/boolti/data/repository/SearchRepositoryImpl.kt
+++ b/data/src/main/java/com/nexters/boolti/data/repository/SearchRepositoryImpl.kt
@@ -35,18 +35,10 @@ internal class SearchRepositoryImpl @Inject constructor(
         searchDataSource.getProfiles(keyword, page, 10)
     }
 
-    // TODO: API 연동 시 searchDataSource.getPlaces(keyword, page, 10) 로 교체
     override suspend fun searchPlaces(
         keyword: String,
         page: Int,
     ): Result<PagingData<Place>> = suspendRunCatching {
-        PagingData(
-            items = emptyList(),
-            currentPage = page,
-            pageSize = 10,
-            totalElements = 0L,
-            totalPages = 0,
-            hasNext = false,
-        )
+        searchDataSource.getPlaces(keyword, page, 10)
     }
 }

--- a/domain/src/main/java/com/nexters/boolti/domain/model/Place.kt
+++ b/domain/src/main/java/com/nexters/boolti/domain/model/Place.kt
@@ -3,6 +3,7 @@ package com.nexters.boolti.domain.model
 data class Place(
     val id: String,
     val name: String,
-    val address: String,
+    val streetAddress: String,
+    val detailAddress: String,
     val thumbnailImage: String,
 )

--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/PlaceItem.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/PlaceItem.kt
@@ -60,7 +60,7 @@ fun PlaceItem(
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
-                text = "${place.streetAddress} ${place.detailAddress}".trim(),
+                text = "${place.streetAddress.trim()} ${place.detailAddress.trim()}",
                 style = MaterialTheme.typography.bodySmall,
                 color = Grey50,
                 maxLines = 1,

--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/PlaceItem.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/PlaceItem.kt
@@ -60,7 +60,7 @@ fun PlaceItem(
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
-                text = place.address,
+                text = "${place.streetAddress} ${place.detailAddress}".trim(),
                 style = MaterialTheme.typography.bodySmall,
                 color = Grey50,
                 maxLines = 1,
@@ -81,7 +81,8 @@ private fun PlaceItemPreview() {
             place = Place(
                 id = "1",
                 name = "그레이존 라이브바",
-                address = "서울 영등포구 도신로 38 지하1층",
+                streetAddress = "서울 영등포구 도신로 38",
+                detailAddress = "지하1층",
                 thumbnailImage = "",
             ),
             onClick = {},

--- a/presentation/src/main/java/com/nexters/boolti/presentation/component/PlaceItem.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/component/PlaceItem.kt
@@ -60,7 +60,7 @@ fun PlaceItem(
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
-                text = "${place.streetAddress.trim()} ${place.detailAddress.trim()}",
+                text = "${place.streetAddress} ${place.detailAddress}",
                 style = MaterialTheme.typography.bodySmall,
                 color = Grey50,
                 maxLines = 1,


### PR DESCRIPTION
## Issue
- Closes #501

## 작업 내용
- 검색 결과 공연장 탭에 `/app/papi/v1/concert-halls/search` API 연동 (#469 의 stub 교체)
- `Place` 모델 주소를 `streetAddress` / `detailAddress` 로 분리
- 응답 DTO `PlaceResponse` 추가 및 `Place` 매핑

## 리뷰 포인트
- `Place.address` 가 도로명/상세주소 2개 필드로 분리됨. `PlaceItem` 은 디자인(1줄)에 맞춰 두 값을 합쳐 표시