### PR TITLE
[Boolti-506] 알림 클릭 시 티켓 화면 이동 크래시 해결

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 minSdk = "28"
 targetSdk = "36"
-versionCode = "52"
-versionName = "1.14.2"
+versionCode = "53"
+versionName = "1.14.3"
 packageName = "com.nexters.boolti"
 compileSdk = "36"
 targetJvm = "17"

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/HomeNavigationEvent.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/HomeNavigationEvent.kt
@@ -1,5 +1,6 @@
 package com.nexters.boolti.presentation.screen
 
+import com.nexters.boolti.presentation.screen.navigation.HomeRoute
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -7,14 +8,14 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class DeepLinkEvent @Inject constructor() {
-    private val _events = MutableSharedFlow<String>(
+class HomeNavigationEvent @Inject constructor() {
+    private val _events = MutableSharedFlow<HomeRoute>(
         replay = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
     val events = _events.asSharedFlow()
 
-    suspend fun sendEvent(deepLink: String) {
-        _events.emit(deepLink)
+    suspend fun sendEvent(route: HomeRoute) {
+        _events.emit(route)
     }
 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/home/HomeEvent.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/home/HomeEvent.kt
@@ -1,8 +1,10 @@
 package com.nexters.boolti.presentation.screen.home
 
+import com.nexters.boolti.presentation.screen.navigation.HomeRoute
+
 sealed interface HomeEvent {
-    data class DeepLinkEvent(
-        val deepLink: String,
+    data class NavigateToHomeRoute(
+        val route: HomeRoute,
     ) : HomeEvent
 
     data class GiftNotification(

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/home/HomeScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavDestination
@@ -78,7 +77,7 @@ fun HomeScreen(
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
-                is HomeEvent.DeepLinkEvent -> navController.navigate(event.deepLink.toUri())
+                is HomeEvent.NavigateToHomeRoute -> navController.navigate(event.route)
                 is HomeEvent.GiftNotification -> {
                     giftStatus = event.status
                 }

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/home/HomeViewModel.kt
@@ -7,7 +7,7 @@ import com.nexters.boolti.domain.repository.AuthRepository
 import com.nexters.boolti.domain.repository.GiftRepository
 import com.nexters.boolti.domain.repository.TicketingRepository
 import com.nexters.boolti.presentation.base.BaseViewModel
-import com.nexters.boolti.presentation.screen.DeepLinkEvent
+import com.nexters.boolti.presentation.screen.HomeNavigationEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -28,7 +28,7 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val giftRepository: GiftRepository,
-    private val deepLinkEvent: DeepLinkEvent,
+    private val homeNavigationEvent: HomeNavigationEvent,
     private val ticketingRepository: TicketingRepository,
 ) : BaseViewModel() {
     val loggedIn = authRepository.loggedIn.stateIn(
@@ -51,7 +51,7 @@ class HomeViewModel @Inject constructor(
     init {
         fetchUserInfo()
         sendFcmToken()
-        collectDeepLinkEvent()
+        collectHomeNavigationEvent()
     }
 
     private fun fetchUserInfo() {
@@ -67,10 +67,9 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun collectDeepLinkEvent() {
-        deepLinkEvent.events
-            .filter { it.startsWith("https://app.boolti.in/home") }
-            .onEach { sendEvent(HomeEvent.DeepLinkEvent(it)) }
+    private fun collectHomeNavigationEvent() {
+        homeNavigationEvent.events
+            .onEach { sendEvent(HomeEvent.NavigateToHomeRoute(it)) }
             .launchIn(viewModelScope)
     }
 

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/splash/SplashActivity.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/splash/SplashActivity.kt
@@ -51,8 +51,8 @@ class SplashActivity : ComponentActivity() {
                         intent.extras?.getString("type")?.let { type ->
                             val notification = BtNotification(type)
 
-                            notification.deepLink?.let {
-                                viewModel.sendDeepLinkEvent(it)
+                            notification.homeRoute?.let {
+                                viewModel.navigateToHome(it)
                             }
 
                             NotificationManagerCompat.from(this).cancel(notification.id)

--- a/presentation/src/main/java/com/nexters/boolti/presentation/screen/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/screen/splash/SplashViewModel.kt
@@ -3,7 +3,8 @@ package com.nexters.boolti.presentation.screen.splash
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nexters.boolti.domain.repository.ConfigRepository
-import com.nexters.boolti.presentation.screen.DeepLinkEvent
+import com.nexters.boolti.presentation.screen.HomeNavigationEvent
+import com.nexters.boolti.presentation.screen.navigation.HomeRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -11,7 +12,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SplashViewModel @Inject constructor(
     configRepository: ConfigRepository,
-    private val deepLinkEvent: DeepLinkEvent,
+    private val homeNavigationEvent: HomeNavigationEvent,
 ) : ViewModel() {
     init {
         viewModelScope.launch {
@@ -21,10 +22,9 @@ class SplashViewModel @Inject constructor(
 
     val shouldUpdate = configRepository.shouldUpdate()
 
-    fun sendDeepLinkEvent(deeplink: String) {
+    fun navigateToHome(route: HomeRoute) {
         viewModelScope.launch {
-            deepLinkEvent.sendEvent(deeplink)
+            homeNavigationEvent.sendEvent(route)
         }
     }
 }
-

--- a/presentation/src/main/java/com/nexters/boolti/presentation/service/BtFirebaseMessagingService.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/service/BtFirebaseMessagingService.kt
@@ -10,7 +10,6 @@ import com.google.firebase.messaging.RemoteMessage
 import com.nexters.boolti.domain.repository.AuthRepository
 import com.nexters.boolti.presentation.R
 import com.nexters.boolti.presentation.extension.checkGrantedPermission
-import com.nexters.boolti.presentation.screen.DeepLinkEvent
 import com.nexters.boolti.presentation.screen.splash.SplashActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -27,9 +26,6 @@ class BtFirebaseMessagingService : FirebaseMessagingService() {
 
     @Inject
     lateinit var authRepository: AuthRepository
-
-    @Inject
-    lateinit var deepLinkEvent: DeepLinkEvent
 
     override fun onNewToken(token: String) {
         scope.launch {

--- a/presentation/src/main/java/com/nexters/boolti/presentation/service/BtNotification.kt
+++ b/presentation/src/main/java/com/nexters/boolti/presentation/service/BtNotification.kt
@@ -1,9 +1,11 @@
 package com.nexters.boolti.presentation.service
 
-enum class BtNotification(val id: Int, val type: String, val deepLink: String?) {
-    RESERVATION_COMPLETED(id = 0, type = "RESERVATION_COMPLETED", deepLink = "https://app.boolti.in/home/tickets"),
-    ENTER_NOTIFICATION(id = 3, type = "ENTER_NOTIFICATION", deepLink = "https://app.boolti.in/home/tickets"),
-    UNDEFINED(id = -1, type = "UNDEFINED", deepLink = null),
+import com.nexters.boolti.presentation.screen.navigation.HomeRoute
+
+enum class BtNotification(val id: Int, val type: String, val homeRoute: HomeRoute?) {
+    RESERVATION_COMPLETED(id = 0, type = "RESERVATION_COMPLETED", homeRoute = HomeRoute.Ticket),
+    ENTER_NOTIFICATION(id = 3, type = "ENTER_NOTIFICATION", homeRoute = HomeRoute.Ticket),
+    UNDEFINED(id = -1, type = "UNDEFINED", homeRoute = null),
 }
 
 fun BtNotification(type: String?): BtNotification {


### PR DESCRIPTION
## Issue
- Closes #506

## 작업 내용
- 예약 완료·입장 알림이 티켓 탭으로 안정적으로 이동하도록 변경
- 내부 알림 이동을 URI 딥링크 대신 `HomeRoute` 직접 이동으로 변경
- hotfix 버전을 `1.14.3`으로 상향

## 리뷰 포인트
- 외부 URI 딥링크는 유지하고, 앱 내부 알림 이동만 타입 안전한 route로 분리함

<img src="" width="300" />